### PR TITLE
rename paragraph token to text

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -283,7 +283,7 @@
         "value": "1.1111111111111112rem",
         "type": "fontSizes"
       },
-      "paragraph": {
+      "text": {
         "value": "1.25rem",
         "type": "fontSizes"
       },
@@ -335,7 +335,7 @@
         "value": "146.25%",
         "type": "lineHeights"
       },
-      "paragraph": {
+      "text": {
         "value": "130%",
         "type": "lineHeights"
       },

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 07 Sep 2022 15:42:09 GMT
+// Generated on Mon, 12 Sep 2022 18:58:56 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -66,7 +66,7 @@ $gcds-font-families-body: Noto Sans;
 $gcds-font-families-monospace: Menlo;
 $gcds-font-families-icons: Glyphicons Halflings;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
-$gcds-font-sizes-paragraph: 1.25rem;
+$gcds-font-sizes-text: 1.25rem;
 $gcds-font-sizes-h6: 1.40625rem;
 $gcds-font-sizes-h5: 1.58203125rem;
 $gcds-font-sizes-h4: 1.77978515625rem;
@@ -78,7 +78,7 @@ $gcds-font-weights-regular: 400;
 $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
 $gcds-line-heights-caption: 146.25%;
-$gcds-line-heights-paragraph: 130%;
+$gcds-line-heights-text: 130%;
 $gcds-line-heights-h6: 115.55555555555556%;
 $gcds-line-heights-h5: 102.71604938271605%;
 $gcds-line-heights-h4: 182.60631001371743%;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 07 Sep 2022 15:42:09 GMT
+ * Generated on Mon, 12 Sep 2022 18:58:56 GMT
  */
 
 :root {
@@ -68,7 +68,7 @@
   --gcds-font-families-monospace: Menlo;
   --gcds-font-families-icons: Glyphicons Halflings;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
-  --gcds-font-sizes-paragraph: 1.25rem;
+  --gcds-font-sizes-text: 1.25rem;
   --gcds-font-sizes-h6: 1.40625rem;
   --gcds-font-sizes-h5: 1.58203125rem;
   --gcds-font-sizes-h4: 1.77978515625rem;
@@ -80,7 +80,7 @@
   --gcds-font-weights-semibold: 600;
   --gcds-font-weights-bold: 700;
   --gcds-line-heights-caption: 146.25%;
-  --gcds-line-heights-paragraph: 130%;
+  --gcds-line-heights-text: 130%;
   --gcds-line-heights-h6: 115.55555555555556%;
   --gcds-line-heights-h5: 102.71604938271605%;
   --gcds-line-heights-h4: 182.60631001371743%;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-dictionary-example-complete",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "",
   "main": "build.js",
   "scripts": {

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -38,7 +38,7 @@ const fontSizes = {
     value: `${base.fontSize.value / base.scale.value}rem`,
     type: 'fontSizes',
   },
-  paragraph: {
+  text: {
     value: `${base.fontSize.value}rem`,
     type: 'fontSizes',
   },
@@ -98,7 +98,7 @@ const lineHeights = {
     value: `${calculateLineHeight(fontSizes.caption.value)}%`,
     type: 'lineHeights',
   },
-  paragraph: {
+  text: {
     value: `${base.lineHeight.value * 100}%`,
     type: 'lineHeights',
   },


### PR DESCRIPTION
# Summary | Résumé

Rename paragraph token to text to represent all text and not just paragraphs.