### PR TITLE
Fix gcds-stepper colour contrast

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -787,7 +787,7 @@
       },
       "hover": {
         "text": {
-          "value": "#31455C",
+          "value": "#425A76",
           "type": "color"
         }
       },
@@ -1048,7 +1048,7 @@
     },
     "stepper": {
       "text": {
-        "value": "#747A82",
+        "value": "#545961",
         "type": "color"
       }
     },

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 22 Dec 2022 14:39:57 GMT
+// Generated on Fri, 23 Dec 2022 14:47:49 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -158,7 +158,7 @@ $gcds-input-focus-text: #303fc3;
 $gcds-input-focus-shadow: #ffffff;
 $gcds-label-destructive-text: #a62a1e;
 $gcds-lang-toggle-default-text: #26374a;
-$gcds-lang-toggle-hover-text: #31455c;
+$gcds-lang-toggle-hover-text: #425a76;
 $gcds-lang-toggle-focus-background: #303fc3;
 $gcds-lang-toggle-focus-text: #ffffff;
 $gcds-lang-toggle-active-text: #ffffff;
@@ -206,7 +206,7 @@ $gcds-site-menu-selection-text: #000000;
 $gcds-site-menu-submenu-background: #e0e2e5;
 $gcds-site-menu-submenu-box-shadow: #00000030;
 $gcds-site-menu-submenu-trigger-text: #000000;
-$gcds-stepper-text: #747a82;
+$gcds-stepper-text: #545961;
 $gcds-textarea-default-background: #ffffff;
 $gcds-textarea-default-text: #000000;
 $gcds-textarea-destructive: #a62a1e;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 22 Dec 2022 14:39:57 GMT
+ * Generated on Fri, 23 Dec 2022 14:47:49 GMT
  */
 
 :root {
@@ -160,7 +160,7 @@
   --gcds-input-focus-shadow: #ffffff;
   --gcds-label-destructive-text: #a62a1e;
   --gcds-lang-toggle-default-text: #26374a;
-  --gcds-lang-toggle-hover-text: #31455c;
+  --gcds-lang-toggle-hover-text: #425a76;
   --gcds-lang-toggle-focus-background: #303fc3;
   --gcds-lang-toggle-focus-text: #ffffff;
   --gcds-lang-toggle-active-text: #ffffff;
@@ -208,7 +208,7 @@
   --gcds-site-menu-submenu-background: #e0e2e5;
   --gcds-site-menu-submenu-box-shadow: #00000030;
   --gcds-site-menu-submenu-trigger-text: #000000;
-  --gcds-stepper-text: #747a82;
+  --gcds-stepper-text: #545961;
   --gcds-textarea-default-background: #ffffff;
   --gcds-textarea-default-text: #000000;
   --gcds-textarea-destructive: #a62a1e;

--- a/tokens/components/stepper/base.json
+++ b/tokens/components/stepper/base.json
@@ -1,7 +1,7 @@
 {
   "stepper": {
     "text": {
-      "value": "{color.grayscale.700.value}",
+      "value": "{color.grayscale.900.value}",
       "type": "color"
     }
   }


### PR DESCRIPTION
# Summary | Résumé

`gcds-components` repo accessibility tests flagged gcds-stepper for failing colour contrast.

Changing gcds-stepper text from `--gcds-color-grayscale-700`: `#747a82` to `--gcds-color-grayscale-900`: `#545961`.
