### PR TITLE
Commented and introduced octaves to calculateLineHeight.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": true
+}

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -306,7 +306,7 @@
         "type": "lineHeights"
       },
       "paragraph": {
-        "value": "180%",
+        "value": "150%",
         "type": "lineHeights"
       },
       "h6": {

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -164,47 +164,47 @@
     },
     "spacing": {
       "50": {
-        "value": "0.26rem",
+        "value": "0.24rem",
         "type": "spacing"
       },
       "100": {
-        "value": "0.325rem",
+        "value": "0.3rem",
         "type": "spacing"
       },
       "200": {
-        "value": "0.43333333333333335rem",
+        "value": "0.39999999999999997rem",
         "type": "spacing"
       },
       "300": {
-        "value": "0.65rem",
+        "value": "0.6rem",
         "type": "spacing"
       },
       "400": {
-        "value": "1.3rem",
+        "value": "1.2rem",
         "type": "spacing"
       },
       "500": {
-        "value": "2.6rem",
+        "value": "2.4rem",
         "type": "spacing"
       },
       "600": {
-        "value": "3.9000000000000004rem",
+        "value": "3.5999999999999996rem",
         "type": "spacing"
       },
       "700": {
-        "value": "5.2rem",
+        "value": "4.8rem",
         "type": "spacing"
       },
       "800": {
-        "value": "6.5rem",
+        "value": "6rem",
         "type": "spacing"
       },
       "900": {
-        "value": "7.800000000000001rem",
+        "value": "7.199999999999999rem",
         "type": "spacing"
       },
       "1000": {
-        "value": "9.1rem",
+        "value": "8.4rem",
         "type": "spacing"
       }
     },
@@ -214,7 +214,7 @@
         "type": "typography"
       },
       "lineHeight": {
-        "value": 1.3,
+        "value": 1.2,
         "type": "typography"
       },
       "scale": {
@@ -298,39 +298,39 @@
     },
     "lineHeights": {
       "caption": {
-        "value": "146.25%",
+        "value": "202.49999999999994%",
         "type": "lineHeights"
       },
       "text": {
-        "value": "130%",
+        "value": "120%",
         "type": "lineHeights"
       },
       "paragraph": {
-        "value": "195%",
+        "value": "180%",
         "type": "lineHeights"
       },
       "h6": {
-        "value": "115.55555555555556%",
+        "value": "159.99999999999997%",
         "type": "lineHeights"
       },
       "h5": {
-        "value": "102.71604938271605%",
+        "value": "189.62962962962962%",
         "type": "lineHeights"
       },
       "h4": {
-        "value": "136.9547325102881%",
+        "value": "168.559670781893%",
         "type": "lineHeights"
       },
       "h3": {
-        "value": "121.73754000914496%",
+        "value": "149.8308184727938%",
         "type": "lineHeights"
       },
       "h2": {
-        "value": "108.21114667479553%",
+        "value": "166.4786871919931%",
         "type": "lineHeights"
       },
       "h1": {
-        "value": "128.25024791086875%",
+        "value": "147.98105528177163%",
         "type": "lineHeights"
       }
     },

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -298,7 +298,7 @@
     },
     "lineHeights": {
       "caption": {
-        "value": "202.49999999999994%",
+        "value": "135%",
         "type": "lineHeights"
       },
       "text": {
@@ -310,27 +310,27 @@
         "type": "lineHeights"
       },
       "h6": {
-        "value": "159.99999999999997%",
+        "value": "124.44444444444444%",
         "type": "lineHeights"
       },
       "h5": {
-        "value": "189.62962962962962%",
+        "value": "126.41975308641975%",
         "type": "lineHeights"
       },
       "h4": {
-        "value": "168.559670781893%",
+        "value": "126.41975308641973%",
         "type": "lineHeights"
       },
       "h3": {
-        "value": "149.8308184727938%",
+        "value": "124.85901539399482%",
         "type": "lineHeights"
       },
       "h2": {
-        "value": "166.4786871919931%",
+        "value": "122.08437060746162%",
         "type": "lineHeights"
       },
       "h1": {
-        "value": "147.98105528177163%",
+        "value": "118.38484422541731%",
         "type": "lineHeights"
       }
     },

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -305,10 +305,6 @@
         "value": "120%",
         "type": "lineHeights"
       },
-      "paragraph": {
-        "value": "150%",
-        "type": "lineHeights"
-      },
       "h6": {
         "value": "124.44444444444444%",
         "type": "lineHeights"

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -305,6 +305,10 @@
         "value": "130%",
         "type": "lineHeights"
       },
+      "paragraph": {
+        "value": "195%",
+        "type": "lineHeights"
+      },
       "h6": {
         "value": "115.55555555555556%",
         "type": "lineHeights"
@@ -314,15 +318,15 @@
         "type": "lineHeights"
       },
       "h4": {
-        "value": "182.60631001371743%",
+        "value": "136.9547325102881%",
         "type": "lineHeights"
       },
       "h3": {
-        "value": "162.31672001219326%",
+        "value": "121.73754000914496%",
         "type": "lineHeights"
       },
       "h2": {
-        "value": "144.28152889972733%",
+        "value": "108.21114667479553%",
         "type": "lineHeights"
       },
       "h1": {

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 12 Jan 2023 18:16:00 GMT
+// Generated on Thu, 12 Jan 2023 20:58:08 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -70,7 +70,6 @@ $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
 $gcds-line-heights-caption: 135%;
 $gcds-line-heights-text: 120%;
-$gcds-line-heights-paragraph: 150%;
 $gcds-line-heights-h6: 124.44444444444444%;
 $gcds-line-heights-h5: 126.41975308641975%;
 $gcds-line-heights-h4: 126.41975308641973%;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 10 Jan 2023 20:38:24 GMT
+// Generated on Wed, 11 Jan 2023 14:53:46 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -37,19 +37,19 @@ $gcds-container-200: 37.5rem;
 $gcds-container-300: 56.25rem;
 $gcds-container-400: 80rem;
 $gcds-container-500: 100%;
-$gcds-spacing-50: 0.26rem;
-$gcds-spacing-100: 0.325rem;
-$gcds-spacing-200: 0.43333333333333335rem;
-$gcds-spacing-300: 0.65rem;
-$gcds-spacing-400: 1.3rem;
-$gcds-spacing-500: 2.6rem;
-$gcds-spacing-600: 3.9000000000000004rem;
-$gcds-spacing-700: 5.2rem;
-$gcds-spacing-800: 6.5rem;
-$gcds-spacing-900: 7.800000000000001rem;
-$gcds-spacing-1000: 9.1rem;
+$gcds-spacing-50: 0.24rem;
+$gcds-spacing-100: 0.3rem;
+$gcds-spacing-200: 0.39999999999999997rem;
+$gcds-spacing-300: 0.6rem;
+$gcds-spacing-400: 1.2rem;
+$gcds-spacing-500: 2.4rem;
+$gcds-spacing-600: 3.5999999999999996rem;
+$gcds-spacing-700: 4.8rem;
+$gcds-spacing-800: 6rem;
+$gcds-spacing-900: 7.199999999999999rem;
+$gcds-spacing-1000: 8.4rem;
 $gcds-base-font-size: 1.25; // Sets base font size to 20px
-$gcds-base-line-height: 1.3;
+$gcds-base-line-height: 1.2;
 $gcds-base-scale: 1.125;
 $gcds-font-families-heading: Lato;
 $gcds-font-families-body: Noto Sans;
@@ -68,15 +68,15 @@ $gcds-font-weights-regular: 400;
 $gcds-font-weights-medium: 500;
 $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
-$gcds-line-heights-caption: 146.25%;
-$gcds-line-heights-text: 130%;
-$gcds-line-heights-paragraph: 195%;
-$gcds-line-heights-h6: 115.55555555555556%;
-$gcds-line-heights-h5: 102.71604938271605%;
-$gcds-line-heights-h4: 136.9547325102881%;
-$gcds-line-heights-h3: 121.73754000914496%;
-$gcds-line-heights-h2: 108.21114667479553%;
-$gcds-line-heights-h1: 128.25024791086875%;
+$gcds-line-heights-caption: 202.49999999999994%;
+$gcds-line-heights-text: 120%;
+$gcds-line-heights-paragraph: 180%;
+$gcds-line-heights-h6: 159.99999999999997%;
+$gcds-line-heights-h5: 189.62962962962962%;
+$gcds-line-heights-h4: 168.559670781893%;
+$gcds-line-heights-h3: 149.8308184727938%;
+$gcds-line-heights-h2: 166.4786871919931%;
+$gcds-line-heights-h1: 147.98105528177163%;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;
 $gcds-alert-text: #000000;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 11 Jan 2023 14:53:46 GMT
+// Generated on Wed, 11 Jan 2023 20:38:31 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -68,15 +68,15 @@ $gcds-font-weights-regular: 400;
 $gcds-font-weights-medium: 500;
 $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
-$gcds-line-heights-caption: 202.49999999999994%;
+$gcds-line-heights-caption: 135%;
 $gcds-line-heights-text: 120%;
 $gcds-line-heights-paragraph: 180%;
-$gcds-line-heights-h6: 159.99999999999997%;
-$gcds-line-heights-h5: 189.62962962962962%;
-$gcds-line-heights-h4: 168.559670781893%;
-$gcds-line-heights-h3: 149.8308184727938%;
-$gcds-line-heights-h2: 166.4786871919931%;
-$gcds-line-heights-h1: 147.98105528177163%;
+$gcds-line-heights-h6: 124.44444444444444%;
+$gcds-line-heights-h5: 126.41975308641975%;
+$gcds-line-heights-h4: 126.41975308641973%;
+$gcds-line-heights-h3: 124.85901539399482%;
+$gcds-line-heights-h2: 122.08437060746162%;
+$gcds-line-heights-h1: 118.38484422541731%;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;
 $gcds-alert-text: #000000;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 11 Jan 2023 20:38:31 GMT
+// Generated on Thu, 12 Jan 2023 18:16:00 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -70,7 +70,7 @@ $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
 $gcds-line-heights-caption: 135%;
 $gcds-line-heights-text: 120%;
-$gcds-line-heights-paragraph: 180%;
+$gcds-line-heights-paragraph: 150%;
 $gcds-line-heights-h6: 124.44444444444444%;
 $gcds-line-heights-h5: 126.41975308641975%;
 $gcds-line-heights-h4: 126.41975308641973%;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 10 Jan 2023 14:15:21 GMT
+// Generated on Tue, 10 Jan 2023 20:38:24 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -70,11 +70,12 @@ $gcds-font-weights-semibold: 600;
 $gcds-font-weights-bold: 700;
 $gcds-line-heights-caption: 146.25%;
 $gcds-line-heights-text: 130%;
+$gcds-line-heights-paragraph: 195%;
 $gcds-line-heights-h6: 115.55555555555556%;
 $gcds-line-heights-h5: 102.71604938271605%;
-$gcds-line-heights-h4: 182.60631001371743%;
-$gcds-line-heights-h3: 162.31672001219326%;
-$gcds-line-heights-h2: 144.28152889972733%;
+$gcds-line-heights-h4: 136.9547325102881%;
+$gcds-line-heights-h3: 121.73754000914496%;
+$gcds-line-heights-h2: 108.21114667479553%;
 $gcds-line-heights-h1: 128.25024791086875%;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 10 Jan 2023 20:38:24 GMT
+ * Generated on Wed, 11 Jan 2023 14:53:46 GMT
  */
 
 :root {
@@ -39,19 +39,19 @@
   --gcds-container-300: 56.25rem;
   --gcds-container-400: 80rem;
   --gcds-container-500: 100%;
-  --gcds-spacing-50: 0.26rem;
-  --gcds-spacing-100: 0.325rem;
-  --gcds-spacing-200: 0.43333333333333335rem;
-  --gcds-spacing-300: 0.65rem;
-  --gcds-spacing-400: 1.3rem;
-  --gcds-spacing-500: 2.6rem;
-  --gcds-spacing-600: 3.9000000000000004rem;
-  --gcds-spacing-700: 5.2rem;
-  --gcds-spacing-800: 6.5rem;
-  --gcds-spacing-900: 7.800000000000001rem;
-  --gcds-spacing-1000: 9.1rem;
+  --gcds-spacing-50: 0.24rem;
+  --gcds-spacing-100: 0.3rem;
+  --gcds-spacing-200: 0.39999999999999997rem;
+  --gcds-spacing-300: 0.6rem;
+  --gcds-spacing-400: 1.2rem;
+  --gcds-spacing-500: 2.4rem;
+  --gcds-spacing-600: 3.5999999999999996rem;
+  --gcds-spacing-700: 4.8rem;
+  --gcds-spacing-800: 6rem;
+  --gcds-spacing-900: 7.199999999999999rem;
+  --gcds-spacing-1000: 8.4rem;
   --gcds-base-font-size: 1.25; /* Sets base font size to 20px */
-  --gcds-base-line-height: 1.3;
+  --gcds-base-line-height: 1.2;
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: Lato;
   --gcds-font-families-body: Noto Sans;
@@ -70,15 +70,15 @@
   --gcds-font-weights-medium: 500;
   --gcds-font-weights-semibold: 600;
   --gcds-font-weights-bold: 700;
-  --gcds-line-heights-caption: 146.25%;
-  --gcds-line-heights-text: 130%;
-  --gcds-line-heights-paragraph: 195%;
-  --gcds-line-heights-h6: 115.55555555555556%;
-  --gcds-line-heights-h5: 102.71604938271605%;
-  --gcds-line-heights-h4: 136.9547325102881%;
-  --gcds-line-heights-h3: 121.73754000914496%;
-  --gcds-line-heights-h2: 108.21114667479553%;
-  --gcds-line-heights-h1: 128.25024791086875%;
+  --gcds-line-heights-caption: 202.49999999999994%;
+  --gcds-line-heights-text: 120%;
+  --gcds-line-heights-paragraph: 180%;
+  --gcds-line-heights-h6: 159.99999999999997%;
+  --gcds-line-heights-h5: 189.62962962962962%;
+  --gcds-line-heights-h4: 168.559670781893%;
+  --gcds-line-heights-h3: 149.8308184727938%;
+  --gcds-line-heights-h2: 166.4786871919931%;
+  --gcds-line-heights-h1: 147.98105528177163%;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 11 Jan 2023 14:53:46 GMT
+ * Generated on Wed, 11 Jan 2023 20:38:31 GMT
  */
 
 :root {
@@ -70,15 +70,15 @@
   --gcds-font-weights-medium: 500;
   --gcds-font-weights-semibold: 600;
   --gcds-font-weights-bold: 700;
-  --gcds-line-heights-caption: 202.49999999999994%;
+  --gcds-line-heights-caption: 135%;
   --gcds-line-heights-text: 120%;
   --gcds-line-heights-paragraph: 180%;
-  --gcds-line-heights-h6: 159.99999999999997%;
-  --gcds-line-heights-h5: 189.62962962962962%;
-  --gcds-line-heights-h4: 168.559670781893%;
-  --gcds-line-heights-h3: 149.8308184727938%;
-  --gcds-line-heights-h2: 166.4786871919931%;
-  --gcds-line-heights-h1: 147.98105528177163%;
+  --gcds-line-heights-h6: 124.44444444444444%;
+  --gcds-line-heights-h5: 126.41975308641975%;
+  --gcds-line-heights-h4: 126.41975308641973%;
+  --gcds-line-heights-h3: 124.85901539399482%;
+  --gcds-line-heights-h2: 122.08437060746162%;
+  --gcds-line-heights-h1: 118.38484422541731%;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 12 Jan 2023 18:16:00 GMT
+ * Generated on Thu, 12 Jan 2023 20:58:08 GMT
  */
 
 :root {
@@ -72,7 +72,6 @@
   --gcds-font-weights-bold: 700;
   --gcds-line-heights-caption: 135%;
   --gcds-line-heights-text: 120%;
-  --gcds-line-heights-paragraph: 150%;
   --gcds-line-heights-h6: 124.44444444444444%;
   --gcds-line-heights-h5: 126.41975308641975%;
   --gcds-line-heights-h4: 126.41975308641973%;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 11 Jan 2023 20:38:31 GMT
+ * Generated on Thu, 12 Jan 2023 18:16:00 GMT
  */
 
 :root {
@@ -72,7 +72,7 @@
   --gcds-font-weights-bold: 700;
   --gcds-line-heights-caption: 135%;
   --gcds-line-heights-text: 120%;
-  --gcds-line-heights-paragraph: 180%;
+  --gcds-line-heights-paragraph: 150%;
   --gcds-line-heights-h6: 124.44444444444444%;
   --gcds-line-heights-h5: 126.41975308641975%;
   --gcds-line-heights-h4: 126.41975308641973%;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 10 Jan 2023 14:15:21 GMT
+ * Generated on Tue, 10 Jan 2023 20:38:24 GMT
  */
 
 :root {
@@ -72,11 +72,12 @@
   --gcds-font-weights-bold: 700;
   --gcds-line-heights-caption: 146.25%;
   --gcds-line-heights-text: 130%;
+  --gcds-line-heights-paragraph: 195%;
   --gcds-line-heights-h6: 115.55555555555556%;
   --gcds-line-heights-h5: 102.71604938271605%;
-  --gcds-line-heights-h4: 182.60631001371743%;
-  --gcds-line-heights-h3: 162.31672001219326%;
-  --gcds-line-heights-h2: 144.28152889972733%;
+  --gcds-line-heights-h4: 136.9547325102881%;
+  --gcds-line-heights-h3: 121.73754000914496%;
+  --gcds-line-heights-h2: 108.21114667479553%;
   --gcds-line-heights-h1: 128.25024791086875%;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -5,7 +5,7 @@ const base = {
 		comment: "Sets base font size to 20px",
 	},
 	lineHeight: {
-		value: 1.3,
+		value: 1.4,
 		type: "typography",
 	},
 	scale: {
@@ -95,13 +95,14 @@ const calculateLineHeight = (fontSize) => {
 	/* 
 		Get fontSize value, divided away from the base font scaling
 		LineHeight has no units, its relative. 
-		Find out how many baseline octaves are required to fit the fontSize
+		Find out how many baseline octaves are required to fit the fontSize. Add one octave for a bit more spacing		
 		Return numBaseline as a percentage for fontSizeValue
 	*/
-	let octave = 2;
+	let octave = 7;
 	let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
 	let numBaselines =
-		Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave;
+		Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave +
+		1 / octave;
 
 	return (numBaselines * base.lineHeight.value * 100) / fontSizeValue;
 };

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -92,12 +92,12 @@ const fontWeights = {
 };
 
 const calculateLineHeight = (fontSize) => {
-  /* 
-		Get fontSize value, divided away from the base font scaling
-		LineHeight has no units, its relative. 
-		Find out how many baseline octaves are required to fit the fontSize. Add one octave for a bit more spacing		
-		Return numBaseline as a percentage for fontSizeValue
-	*/
+  /*
+  Get fontSize value, divided away from the base font scaling
+  LineHeight has no units, its relative.
+  Find out how many baseline octaves are required to fit the fontSize. Add one octave for a bit more spacing
+  Return numBaseline as a percentage for fontSizeValue
+  */
   let octave = 6;
   let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
   let numBaselines =
@@ -119,7 +119,7 @@ const lineHeights = {
     type: 'lineHeights',
   },
   paragraph: {
-    value: `${base.lineHeight.value * 150}%`,
+    value: `150%`,
     type: 'lineHeights',
   },
   h6: {

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -1,93 +1,93 @@
 const base = {
   fontSize: {
     value: 1.25,
-    type: "typography",
-    comment: "Sets base font size to 20px",
+    type: 'typography',
+    comment: 'Sets base font size to 20px',
   },
   lineHeight: {
     value: 1.2,
-    type: "typography",
+    type: 'typography',
   },
   scale: {
     value: 1.125,
-    type: "typography",
+    type: 'typography',
   },
 };
 
 const fontFamilies = {
   heading: {
-    value: "Lato",
-    type: "fontFamilies",
+    value: 'Lato',
+    type: 'fontFamilies',
   },
   body: {
-    value: "Noto Sans",
-    type: "fontFamilies",
+    value: 'Noto Sans',
+    type: 'fontFamilies',
   },
   monospace: {
-    value: "Menlo",
-    type: "fontFamilies",
+    value: 'Menlo',
+    type: 'fontFamilies',
   },
   icons: {
-    value: "Glyphicons Halflings",
-    type: "fontFamilies",
+    value: 'Glyphicons Halflings',
+    type: 'fontFamilies',
   },
 };
 
 const fontSizes = {
   caption: {
     value: `${base.fontSize.value / base.scale.value}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   text: {
     value: `${base.fontSize.value}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h6: {
     value: `${base.fontSize.value * base.scale.value}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h5: {
     value: `${base.fontSize.value * base.scale.value ** 2}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h4: {
     value: `${base.fontSize.value * base.scale.value ** 3}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h3: {
     value: `${base.fontSize.value * base.scale.value ** 4}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h2: {
     value: `${base.fontSize.value * base.scale.value ** 5}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
   h1: {
     value: `${base.fontSize.value * base.scale.value ** 6}rem`,
-    type: "fontSizes",
+    type: 'fontSizes',
   },
 };
 
 const fontWeights = {
   light: {
-    value: "300",
-    type: "fontWeights",
+    value: '300',
+    type: 'fontWeights',
   },
   regular: {
-    value: "400",
-    type: "fontWeights",
+    value: '400',
+    type: 'fontWeights',
   },
   medium: {
-    value: "500",
-    type: "fontWeights",
+    value: '500',
+    type: 'fontWeights',
   },
   semibold: {
-    value: "600",
-    type: "fontWeights",
+    value: '600',
+    type: 'fontWeights',
   },
   bold: {
-    value: "700",
-    type: "fontWeights",
+    value: '700',
+    type: 'fontWeights',
   },
 };
 
@@ -112,39 +112,39 @@ const calculateLineHeight = (fontSize) => {
 const lineHeights = {
   caption: {
     value: `${calculateLineHeight(fontSizes.caption.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   text: {
     value: `${base.lineHeight.value * 100}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   paragraph: {
     value: `${base.lineHeight.value * 150}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h6: {
     value: `${calculateLineHeight(fontSizes.h6.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h5: {
     value: `${calculateLineHeight(fontSizes.h5.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h4: {
     value: `${calculateLineHeight(fontSizes.h4.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h3: {
     value: `${calculateLineHeight(fontSizes.h3.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h2: {
     value: `${calculateLineHeight(fontSizes.h2.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
   h1: {
     value: `${calculateLineHeight(fontSizes.h1.value)}%`,
-    type: "lineHeights",
+    type: 'lineHeights',
   },
 };
 

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -118,10 +118,6 @@ const lineHeights = {
     value: `${base.lineHeight.value * 100}%`,
     type: 'lineHeights',
   },
-  paragraph: {
-    value: `150%`,
-    type: 'lineHeights',
-  },
   h6: {
     value: `${calculateLineHeight(fontSizes.h6.value)}%`,
     type: 'lineHeights',

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -1,141 +1,156 @@
 const base = {
-  fontSize: {
-    value: 1.25,
-    type: 'typography',
-    comment: 'Sets base font size to 20px'
-  },
-  lineHeight: {
-    value: 1.3,
-    type: 'typography',
-  },
-  scale: {
-    value: 1.125,
-    type: 'typography',
-  },
-}
+	fontSize: {
+		value: 1.25,
+		type: "typography",
+		comment: "Sets base font size to 20px",
+	},
+	lineHeight: {
+		value: 1.3,
+		type: "typography",
+	},
+	scale: {
+		value: 1.125,
+		type: "typography",
+	},
+};
 
 const fontFamilies = {
-  heading: {
-    value: 'Lato',
-    type: 'fontFamilies',
-  },
-  body: {
-    value: 'Noto Sans',
-    type: 'fontFamilies',
-  },
-  monospace: {
-    value: 'Menlo',
-    type: 'fontFamilies',
-  },
-  icons: {
-    value: 'Glyphicons Halflings',
-    type: 'fontFamilies',
-  }
-}
+	heading: {
+		value: "Lato",
+		type: "fontFamilies",
+	},
+	body: {
+		value: "Noto Sans",
+		type: "fontFamilies",
+	},
+	monospace: {
+		value: "Menlo",
+		type: "fontFamilies",
+	},
+	icons: {
+		value: "Glyphicons Halflings",
+		type: "fontFamilies",
+	},
+};
 
 const fontSizes = {
-  caption: {
-    value: `${base.fontSize.value / base.scale.value}rem`,
-    type: 'fontSizes',
-  },
-  text: {
-    value: `${base.fontSize.value}rem`,
-    type: 'fontSizes',
-  },
-  h6: {
-    value: `${base.fontSize.value * base.scale.value}rem`,
-    type: 'fontSizes',
-  },
-  h5: {
-    value: `${base.fontSize.value * base.scale.value ** 2}rem`,
-    type: 'fontSizes',
-  },
-  h4: {
-    value: `${base.fontSize.value * base.scale.value ** 3}rem`,
-    type: 'fontSizes',
-  },
-  h3: {
-    value: `${base.fontSize.value * base.scale.value ** 4}rem`,
-    type: 'fontSizes',
-  },
-  h2: {
-    value: `${base.fontSize.value * base.scale.value ** 5}rem`,
-    type: 'fontSizes',
-  },
-  h1: {
-    value: `${base.fontSize.value * base.scale.value ** 6}rem`,
-    type: 'fontSizes',
-  }
-}
+	caption: {
+		value: `${base.fontSize.value / base.scale.value}rem`,
+		type: "fontSizes",
+	},
+	text: {
+		value: `${base.fontSize.value}rem`,
+		type: "fontSizes",
+	},
+	h6: {
+		value: `${base.fontSize.value * base.scale.value}rem`,
+		type: "fontSizes",
+	},
+	h5: {
+		value: `${base.fontSize.value * base.scale.value ** 2}rem`,
+		type: "fontSizes",
+	},
+	h4: {
+		value: `${base.fontSize.value * base.scale.value ** 3}rem`,
+		type: "fontSizes",
+	},
+	h3: {
+		value: `${base.fontSize.value * base.scale.value ** 4}rem`,
+		type: "fontSizes",
+	},
+	h2: {
+		value: `${base.fontSize.value * base.scale.value ** 5}rem`,
+		type: "fontSizes",
+	},
+	h1: {
+		value: `${base.fontSize.value * base.scale.value ** 6}rem`,
+		type: "fontSizes",
+	},
+};
 
 const fontWeights = {
-  light: {
-    value: '300',
-    type: 'fontWeights',
-  },
-  regular: {
-    value: '400',
-    type: 'fontWeights',
-  },
-  medium: {
-    value: '500',
-    type: 'fontWeights',
-  },
-  semibold: {
-    value: '600',
-    type: 'fontWeights',
-  },
-  bold: {
-    value: '700',
-    type: 'fontWeights',
-  }
-}
+	light: {
+		value: "300",
+		type: "fontWeights",
+	},
+	regular: {
+		value: "400",
+		type: "fontWeights",
+	},
+	medium: {
+		value: "500",
+		type: "fontWeights",
+	},
+	semibold: {
+		value: "600",
+		type: "fontWeights",
+	},
+	bold: {
+		value: "700",
+		type: "fontWeights",
+	},
+};
 
 const calculateLineHeight = (fontSize) => {
-  return Math.ceil(parseFloat(fontSize) / base.fontSize.value / base.lineHeight.value) * base.lineHeight.value * 100 / (parseFloat(fontSize) / base.fontSize.value)
+	/* 
+		Get fontSize value, divided away from the base font scaling
+		LineHeight has no units, its relative. 
+		Find out how many baseline octaves are required to fit the fontSize
+		Return numBaseline as a percentage for fontSizeValue
+	*/
+	let octave = 2;
+	let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
+	let numBaselines =
+		Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave;
+
+	return (numBaselines * base.lineHeight.value * 100) / fontSizeValue;
 };
 
 // Line height needs to be calculated in percentage in order for it
 // to work properly in Figma + Web
 const lineHeights = {
-  caption: {
-    value: `${calculateLineHeight(fontSizes.caption.value)}%`,
-    type: 'lineHeights',
-  },
-  text: {
-    value: `${base.lineHeight.value * 100}%`,
-    type: 'lineHeights',
-  },
-  h6: {
-    value: `${calculateLineHeight(fontSizes.h6.value)}%`,
-    type: 'lineHeights',
-  },
-  h5: {
-    value: `${calculateLineHeight(fontSizes.h5.value)}%`,
-    type: 'lineHeights',
-  },
-  h4: {
-    value: `${calculateLineHeight(fontSizes.h4.value)}%`,
-    type: 'lineHeights',
-  },
-  h3: {
-    value: `${calculateLineHeight(fontSizes.h3.value)}%`,
-    type: 'lineHeights',
-  },
-  h2: {
-    value: `${calculateLineHeight(fontSizes.h2.value)}%`,
-    type: 'lineHeights',
-  },
-  h1: {
-    value: `${calculateLineHeight(fontSizes.h1.value)}%`,
-    type: 'lineHeights',
-  }
-}
+	caption: {
+		value: `${calculateLineHeight(fontSizes.caption.value)}%`,
+		type: "lineHeights",
+	},
+	text: {
+		value: `${base.lineHeight.value * 100}%`,
+		type: "lineHeights",
+	},
+	paragraph: {
+		value: `${base.lineHeight.value * 150}%`,
+		type: "lineHeights",
+	},
+	h6: {
+		value: `${calculateLineHeight(fontSizes.h6.value)}%`,
+		type: "lineHeights",
+	},
+	h5: {
+		value: `${calculateLineHeight(fontSizes.h5.value)}%`,
+		type: "lineHeights",
+	},
+	h4: {
+		value: `${calculateLineHeight(fontSizes.h4.value)}%`,
+		type: "lineHeights",
+	},
+	h3: {
+		value: `${calculateLineHeight(fontSizes.h3.value)}%`,
+		type: "lineHeights",
+	},
+	h2: {
+		value: `${calculateLineHeight(fontSizes.h2.value)}%`,
+		type: "lineHeights",
+	},
+	h1: {
+		value: `${calculateLineHeight(fontSizes.h1.value)}%`,
+		type: "lineHeights",
+	},
+};
 
 module.exports = {
-  base,
-  fontFamilies,
-  fontSizes,
-  fontWeights,
-  lineHeights,
+	base,
+	fontFamilies,
+	fontSizes,
+	fontWeights,
+	lineHeights,
 };

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -5,7 +5,7 @@ const base = {
 		comment: "Sets base font size to 20px",
 	},
 	lineHeight: {
-		value: 1.4,
+		value: 1.2,
 		type: "typography",
 	},
 	scale: {
@@ -98,7 +98,7 @@ const calculateLineHeight = (fontSize) => {
 		Find out how many baseline octaves are required to fit the fontSize. Add one octave for a bit more spacing		
 		Return numBaseline as a percentage for fontSizeValue
 	*/
-	let octave = 7;
+	let octave = 6;
 	let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
 	let numBaselines =
 		Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave +

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -1,157 +1,157 @@
 const base = {
-	fontSize: {
-		value: 1.25,
-		type: "typography",
-		comment: "Sets base font size to 20px",
-	},
-	lineHeight: {
-		value: 1.2,
-		type: "typography",
-	},
-	scale: {
-		value: 1.125,
-		type: "typography",
-	},
+  fontSize: {
+    value: 1.25,
+    type: "typography",
+    comment: "Sets base font size to 20px",
+  },
+  lineHeight: {
+    value: 1.2,
+    type: "typography",
+  },
+  scale: {
+    value: 1.125,
+    type: "typography",
+  },
 };
 
 const fontFamilies = {
-	heading: {
-		value: "Lato",
-		type: "fontFamilies",
-	},
-	body: {
-		value: "Noto Sans",
-		type: "fontFamilies",
-	},
-	monospace: {
-		value: "Menlo",
-		type: "fontFamilies",
-	},
-	icons: {
-		value: "Glyphicons Halflings",
-		type: "fontFamilies",
-	},
+  heading: {
+    value: "Lato",
+    type: "fontFamilies",
+  },
+  body: {
+    value: "Noto Sans",
+    type: "fontFamilies",
+  },
+  monospace: {
+    value: "Menlo",
+    type: "fontFamilies",
+  },
+  icons: {
+    value: "Glyphicons Halflings",
+    type: "fontFamilies",
+  },
 };
 
 const fontSizes = {
-	caption: {
-		value: `${base.fontSize.value / base.scale.value}rem`,
-		type: "fontSizes",
-	},
-	text: {
-		value: `${base.fontSize.value}rem`,
-		type: "fontSizes",
-	},
-	h6: {
-		value: `${base.fontSize.value * base.scale.value}rem`,
-		type: "fontSizes",
-	},
-	h5: {
-		value: `${base.fontSize.value * base.scale.value ** 2}rem`,
-		type: "fontSizes",
-	},
-	h4: {
-		value: `${base.fontSize.value * base.scale.value ** 3}rem`,
-		type: "fontSizes",
-	},
-	h3: {
-		value: `${base.fontSize.value * base.scale.value ** 4}rem`,
-		type: "fontSizes",
-	},
-	h2: {
-		value: `${base.fontSize.value * base.scale.value ** 5}rem`,
-		type: "fontSizes",
-	},
-	h1: {
-		value: `${base.fontSize.value * base.scale.value ** 6}rem`,
-		type: "fontSizes",
-	},
+  caption: {
+    value: `${base.fontSize.value / base.scale.value}rem`,
+    type: "fontSizes",
+  },
+  text: {
+    value: `${base.fontSize.value}rem`,
+    type: "fontSizes",
+  },
+  h6: {
+    value: `${base.fontSize.value * base.scale.value}rem`,
+    type: "fontSizes",
+  },
+  h5: {
+    value: `${base.fontSize.value * base.scale.value ** 2}rem`,
+    type: "fontSizes",
+  },
+  h4: {
+    value: `${base.fontSize.value * base.scale.value ** 3}rem`,
+    type: "fontSizes",
+  },
+  h3: {
+    value: `${base.fontSize.value * base.scale.value ** 4}rem`,
+    type: "fontSizes",
+  },
+  h2: {
+    value: `${base.fontSize.value * base.scale.value ** 5}rem`,
+    type: "fontSizes",
+  },
+  h1: {
+    value: `${base.fontSize.value * base.scale.value ** 6}rem`,
+    type: "fontSizes",
+  },
 };
 
 const fontWeights = {
-	light: {
-		value: "300",
-		type: "fontWeights",
-	},
-	regular: {
-		value: "400",
-		type: "fontWeights",
-	},
-	medium: {
-		value: "500",
-		type: "fontWeights",
-	},
-	semibold: {
-		value: "600",
-		type: "fontWeights",
-	},
-	bold: {
-		value: "700",
-		type: "fontWeights",
-	},
+  light: {
+    value: "300",
+    type: "fontWeights",
+  },
+  regular: {
+    value: "400",
+    type: "fontWeights",
+  },
+  medium: {
+    value: "500",
+    type: "fontWeights",
+  },
+  semibold: {
+    value: "600",
+    type: "fontWeights",
+  },
+  bold: {
+    value: "700",
+    type: "fontWeights",
+  },
 };
 
 const calculateLineHeight = (fontSize) => {
-	/* 
+  /* 
 		Get fontSize value, divided away from the base font scaling
 		LineHeight has no units, its relative. 
 		Find out how many baseline octaves are required to fit the fontSize. Add one octave for a bit more spacing		
 		Return numBaseline as a percentage for fontSizeValue
 	*/
-	let octave = 6;
-	let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
-	let numBaselines =
-		Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave +
-		1 / octave;
+  let octave = 6;
+  let fontSizeValue = parseFloat(fontSize) / base.fontSize.value;
+  let numBaselines =
+    Math.ceil((fontSizeValue * octave) / base.lineHeight.value) / octave +
+    1 / octave;
 
-	return (numBaselines * base.lineHeight.value * 100) / fontSizeValue;
+  return (numBaselines * base.lineHeight.value * 100) / fontSizeValue;
 };
 
 // Line height needs to be calculated in percentage in order for it
 // to work properly in Figma + Web
 const lineHeights = {
-	caption: {
-		value: `${calculateLineHeight(fontSizes.caption.value)}%`,
-		type: "lineHeights",
-	},
-	text: {
-		value: `${base.lineHeight.value * 100}%`,
-		type: "lineHeights",
-	},
-	paragraph: {
-		value: `${base.lineHeight.value * 150}%`,
-		type: "lineHeights",
-	},
-	h6: {
-		value: `${calculateLineHeight(fontSizes.h6.value)}%`,
-		type: "lineHeights",
-	},
-	h5: {
-		value: `${calculateLineHeight(fontSizes.h5.value)}%`,
-		type: "lineHeights",
-	},
-	h4: {
-		value: `${calculateLineHeight(fontSizes.h4.value)}%`,
-		type: "lineHeights",
-	},
-	h3: {
-		value: `${calculateLineHeight(fontSizes.h3.value)}%`,
-		type: "lineHeights",
-	},
-	h2: {
-		value: `${calculateLineHeight(fontSizes.h2.value)}%`,
-		type: "lineHeights",
-	},
-	h1: {
-		value: `${calculateLineHeight(fontSizes.h1.value)}%`,
-		type: "lineHeights",
-	},
+  caption: {
+    value: `${calculateLineHeight(fontSizes.caption.value)}%`,
+    type: "lineHeights",
+  },
+  text: {
+    value: `${base.lineHeight.value * 100}%`,
+    type: "lineHeights",
+  },
+  paragraph: {
+    value: `${base.lineHeight.value * 150}%`,
+    type: "lineHeights",
+  },
+  h6: {
+    value: `${calculateLineHeight(fontSizes.h6.value)}%`,
+    type: "lineHeights",
+  },
+  h5: {
+    value: `${calculateLineHeight(fontSizes.h5.value)}%`,
+    type: "lineHeights",
+  },
+  h4: {
+    value: `${calculateLineHeight(fontSizes.h4.value)}%`,
+    type: "lineHeights",
+  },
+  h3: {
+    value: `${calculateLineHeight(fontSizes.h3.value)}%`,
+    type: "lineHeights",
+  },
+  h2: {
+    value: `${calculateLineHeight(fontSizes.h2.value)}%`,
+    type: "lineHeights",
+  },
+  h1: {
+    value: `${calculateLineHeight(fontSizes.h1.value)}%`,
+    type: "lineHeights",
+  },
 };
 
 module.exports = {
-	base,
-	fontFamilies,
-	fontSizes,
-	fontWeights,
-	lineHeights,
+  base,
+  fontFamilies,
+  fontSizes,
+  fontWeights,
+  lineHeights,
 };


### PR DESCRIPTION
# Summary | Résumé

- Added comments to calculateLineHeight to understand what is happening
- Made the code a bit more readable. I think?
- Added support for octaves. This allows us to fine tune our typographic rhythm

This prioritizes the reader a bit more than a strict baseline grid. 

An example before octaves. All lines are multiples of 26. H3 and H4 looks super spaced out, while h5 and h6 lines are jammed to each other

![image](https://user-images.githubusercontent.com/5230720/211659523-406a60e0-68c4-4b9d-ac24-fcbe050c71f3.png)

An example with 2 octaves. All lines are a multiple of 13 (26/2). H3 and H4 are a bit better. H2 H5 and H6 are still jammed together

![image](https://user-images.githubusercontent.com/5230720/211658560-89c3105e-4cf1-47ac-9fc0-8852fd74b133.png)

Maybe its also about tuning the fontSize scale

