### PR TITLE
Adding typography styles and transform to process as css/scss font prop.

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -350,6 +350,100 @@
         "type": "lineHeights"
       }
     },
+    "typography": {
+      "typography": {
+        "h1": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "118.38484422541731%",
+            "fontSize": "2.5341081619262695rem"
+          },
+          "type": "typography"
+        },
+        "h2": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "122.08437060746162%",
+            "fontSize": "2.2525405883789062rem"
+          },
+          "type": "typography"
+        },
+        "h3": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "124.85901539399482%",
+            "fontSize": "2.00225830078125rem"
+          },
+          "type": "typography"
+        },
+        "h4": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "126.41975308641973%",
+            "fontSize": "1.77978515625rem"
+          },
+          "type": "typography"
+        },
+        "h5": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "126.41975308641975%",
+            "fontSize": "1.58203125rem"
+          },
+          "type": "typography"
+        },
+        "h6": {
+          "value": {
+            "fontFamily": "Lato",
+            "fontWeight": "500",
+            "lineHeight": "124.44444444444444%",
+            "fontSize": "1.40625rem"
+          },
+          "type": "typography"
+        },
+        "label": {
+          "value": {
+            "fontFamily": "Noto Sans",
+            "fontWeight": "500",
+            "lineHeight": "120%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
+        },
+        "hint": {
+          "value": {
+            "fontFamily": "Noto Sans",
+            "fontWeight": "400",
+            "lineHeight": "135%",
+            "fontSize": "1.1111111111111112rem"
+          },
+          "type": "typography"
+        },
+        "text": {
+          "value": {
+            "fontFamily": "Noto Sans",
+            "fontWeight": "400",
+            "lineHeight": "120%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
+        },
+        "paragraph": {
+          "value": {
+            "fontFamily": "Noto Sans",
+            "fontWeight": "400",
+            "lineHeight": "150%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
+        }
+      }
+    },
     "alert": {
       "button": {
         "focus": {

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1991,42 +1991,6 @@
           "type": "fontWeights"
         }
       }
-    },
-    "global": {
-      "default": {
-        "text": {
-          "value": "#000",
-          "type": "color"
-        }
-      },
-      "focus": {
-        "value": "#303FC3",
-        "type": "color"
-      },
-      "active": {
-        "text": {
-          "value": "#FFF",
-          "type": "color"
-        },
-        "background": {
-          "value": "#000",
-          "type": "color"
-        }
-      },
-      "disabled": {
-        "background": {
-          "value": "#D6D9DD",
-          "type": "color"
-        },
-        "text": {
-          "value": "#545961",
-          "type": "color"
-        }
-      },
-      "destructive": {
-        "value": "#A62A1E",
-        "type": "color"
-      }
     }
   }
 }

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -429,7 +429,7 @@
         },
         "type": "typography"
       },
-      "longText": {
+      "textLong": {
         "value": {
           "fontFamily": "Noto Sans",
           "fontWeight": "400",

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -230,16 +230,13 @@
     },
     "base": {
       "fontSize": {
-        "value": 1.25,
-        "type": "typography"
+        "value": 1.25
       },
       "lineHeight": {
-        "value": 1.2,
-        "type": "typography"
+        "value": 1.2
       },
       "scale": {
-        "value": 1.125,
-        "type": "typography"
+        "value": 1.125
       }
     },
     "fontFamilies": {
@@ -350,98 +347,96 @@
         "type": "lineHeights"
       }
     },
-    "typography": {
-      "typography": {
-        "h1": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "118.38484422541731%",
-            "fontSize": "2.5341081619262695rem"
-          },
-          "type": "typography"
+    "font": {
+      "h1": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "118.38484422541731%",
+          "fontSize": "2.5341081619262695rem"
         },
-        "h2": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "122.08437060746162%",
-            "fontSize": "2.2525405883789062rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "h2": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "122.08437060746162%",
+          "fontSize": "2.2525405883789062rem"
         },
-        "h3": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "124.85901539399482%",
-            "fontSize": "2.00225830078125rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "h3": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "124.85901539399482%",
+          "fontSize": "2.00225830078125rem"
         },
-        "h4": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "126.41975308641973%",
-            "fontSize": "1.77978515625rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "h4": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "126.41975308641973%",
+          "fontSize": "1.77978515625rem"
         },
-        "h5": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "126.41975308641975%",
-            "fontSize": "1.58203125rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "h5": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "126.41975308641975%",
+          "fontSize": "1.58203125rem"
         },
-        "h6": {
-          "value": {
-            "fontFamily": "Lato",
-            "fontWeight": "500",
-            "lineHeight": "124.44444444444444%",
-            "fontSize": "1.40625rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "h6": {
+        "value": {
+          "fontFamily": "Lato",
+          "fontWeight": "700",
+          "lineHeight": "124.44444444444444%",
+          "fontSize": "1.40625rem"
         },
-        "label": {
-          "value": {
-            "fontFamily": "Noto Sans",
-            "fontWeight": "500",
-            "lineHeight": "120%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "label": {
+        "value": {
+          "fontFamily": "Noto Sans",
+          "fontWeight": "500",
+          "lineHeight": "120%",
+          "fontSize": "1.25rem"
         },
-        "hint": {
-          "value": {
-            "fontFamily": "Noto Sans",
-            "fontWeight": "400",
-            "lineHeight": "135%",
-            "fontSize": "1.1111111111111112rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "caption": {
+        "value": {
+          "fontFamily": "Noto Sans",
+          "fontWeight": "400",
+          "lineHeight": "135%",
+          "fontSize": "1.1111111111111112rem"
         },
-        "text": {
-          "value": {
-            "fontFamily": "Noto Sans",
-            "fontWeight": "400",
-            "lineHeight": "120%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
+        "type": "typography"
+      },
+      "text": {
+        "value": {
+          "fontFamily": "Noto Sans",
+          "fontWeight": "400",
+          "lineHeight": "120%",
+          "fontSize": "1.25rem"
         },
-        "paragraph": {
-          "value": {
-            "fontFamily": "Noto Sans",
-            "fontWeight": "400",
-            "lineHeight": "150%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
-        }
+        "type": "typography"
+      },
+      "longText": {
+        "value": {
+          "fontFamily": "Noto Sans",
+          "fontWeight": "400",
+          "lineHeight": "150%",
+          "fontSize": "1.25rem"
+        },
+        "type": "typography"
       }
     },
     "alert": {

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 20 Jan 2023 07:31:19 GMT
+// Generated on Mon, 23 Jan 2023 19:32:32 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -409,10 +409,3 @@ $gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
 $gcds-verify-banner-text: #000000;
 $gcds-verify-banner-toggle-text: #26374a;
 $gcds-verify-banner-toggle-font-weight: 700;
-$gcds-global-default-text: #000000;
-$gcds-global-focus: #303fc3;
-$gcds-global-active-text: #ffffff;
-$gcds-global-active-background: #000000;
-$gcds-global-disabled-background: #d6d9dd;
-$gcds-global-disabled-text: #545961;
-$gcds-global-destructive: #a62a1e;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 24 Jan 2023 19:18:21 GMT
+// Generated on Tue, 24 Jan 2023 19:48:58 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -90,7 +90,7 @@ $gcds-font-h6: 700 1.40625rem/124.44444444444444% Lato;
 $gcds-font-label: 500 1.25rem/120% Noto Sans;
 $gcds-font-caption: 400 1.1111111111111112rem/135% Noto Sans;
 $gcds-font-text: 400 1.25rem/120% Noto Sans;
-$gcds-font-long-text: 400 1.25rem/150% Noto Sans;
+$gcds-font-text-long: 400 1.25rem/150% Noto Sans;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;
 $gcds-alert-text: #000000;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 23 Jan 2023 19:32:32 GMT
+// Generated on Mon, 23 Jan 2023 19:41:47 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -81,6 +81,16 @@ $gcds-line-heights-h4: 126.41975308641973%;
 $gcds-line-heights-h3: 124.85901539399482%;
 $gcds-line-heights-h2: 122.08437060746162%;
 $gcds-line-heights-h1: 118.38484422541731%;
+$gcds-typography-typography-h1: 500 2.5341081619262695rem/118.38484422541731% Lato;
+$gcds-typography-typography-h2: 500 2.2525405883789062rem/122.08437060746162% Lato;
+$gcds-typography-typography-h3: 500 2.00225830078125rem/124.85901539399482% Lato;
+$gcds-typography-typography-h4: 500 1.77978515625rem/126.41975308641973% Lato;
+$gcds-typography-typography-h5: 500 1.58203125rem/126.41975308641975% Lato;
+$gcds-typography-typography-h6: 500 1.40625rem/124.44444444444444% Lato;
+$gcds-typography-typography-label: 500 1.25rem/120% Noto Sans;
+$gcds-typography-typography-hint: 400 1.1111111111111112rem/135% Noto Sans;
+$gcds-typography-typography-text: 400 1.25rem/120% Noto Sans;
+$gcds-typography-typography-paragraph: 400 1.25rem/150% Noto Sans;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;
 $gcds-alert-text: #000000;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 24 Jan 2023 19:12:02 GMT
+// Generated on Tue, 24 Jan 2023 19:18:21 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 23 Jan 2023 19:41:47 GMT
+// Generated on Tue, 24 Jan 2023 19:12:02 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;
@@ -81,16 +81,16 @@ $gcds-line-heights-h4: 126.41975308641973%;
 $gcds-line-heights-h3: 124.85901539399482%;
 $gcds-line-heights-h2: 122.08437060746162%;
 $gcds-line-heights-h1: 118.38484422541731%;
-$gcds-typography-typography-h1: 500 2.5341081619262695rem/118.38484422541731% Lato;
-$gcds-typography-typography-h2: 500 2.2525405883789062rem/122.08437060746162% Lato;
-$gcds-typography-typography-h3: 500 2.00225830078125rem/124.85901539399482% Lato;
-$gcds-typography-typography-h4: 500 1.77978515625rem/126.41975308641973% Lato;
-$gcds-typography-typography-h5: 500 1.58203125rem/126.41975308641975% Lato;
-$gcds-typography-typography-h6: 500 1.40625rem/124.44444444444444% Lato;
-$gcds-typography-typography-label: 500 1.25rem/120% Noto Sans;
-$gcds-typography-typography-hint: 400 1.1111111111111112rem/135% Noto Sans;
-$gcds-typography-typography-text: 400 1.25rem/120% Noto Sans;
-$gcds-typography-typography-paragraph: 400 1.25rem/150% Noto Sans;
+$gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% Lato;
+$gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% Lato;
+$gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% Lato;
+$gcds-font-h4: 700 1.77978515625rem/126.41975308641973% Lato;
+$gcds-font-h5: 700 1.58203125rem/126.41975308641975% Lato;
+$gcds-font-h6: 700 1.40625rem/124.44444444444444% Lato;
+$gcds-font-label: 500 1.25rem/120% Noto Sans;
+$gcds-font-caption: 400 1.1111111111111112rem/135% Noto Sans;
+$gcds-font-text: 400 1.25rem/120% Noto Sans;
+$gcds-font-long-text: 400 1.25rem/150% Noto Sans;
 $gcds-alert-button-focus-background: #303fc3;
 $gcds-alert-button-focus-text: #ffffff;
 $gcds-alert-text: #000000;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 23 Jan 2023 19:32:32 GMT
+ * Generated on Mon, 23 Jan 2023 19:41:47 GMT
  */
 
 :root {
@@ -83,6 +83,16 @@
   --gcds-line-heights-h3: 124.85901539399482%;
   --gcds-line-heights-h2: 122.08437060746162%;
   --gcds-line-heights-h1: 118.38484422541731%;
+  --gcds-typography-typography-h1: 500 2.5341081619262695rem/118.38484422541731% Lato;
+  --gcds-typography-typography-h2: 500 2.2525405883789062rem/122.08437060746162% Lato;
+  --gcds-typography-typography-h3: 500 2.00225830078125rem/124.85901539399482% Lato;
+  --gcds-typography-typography-h4: 500 1.77978515625rem/126.41975308641973% Lato;
+  --gcds-typography-typography-h5: 500 1.58203125rem/126.41975308641975% Lato;
+  --gcds-typography-typography-h6: 500 1.40625rem/124.44444444444444% Lato;
+  --gcds-typography-typography-label: 500 1.25rem/120% Noto Sans;
+  --gcds-typography-typography-hint: 400 1.1111111111111112rem/135% Noto Sans;
+  --gcds-typography-typography-text: 400 1.25rem/120% Noto Sans;
+  --gcds-typography-typography-paragraph: 400 1.25rem/150% Noto Sans;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 24 Jan 2023 19:12:02 GMT
+ * Generated on Tue, 24 Jan 2023 19:18:21 GMT
  */
 
 :root {

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 23 Jan 2023 19:41:47 GMT
+ * Generated on Tue, 24 Jan 2023 19:12:02 GMT
  */
 
 :root {
@@ -83,16 +83,16 @@
   --gcds-line-heights-h3: 124.85901539399482%;
   --gcds-line-heights-h2: 122.08437060746162%;
   --gcds-line-heights-h1: 118.38484422541731%;
-  --gcds-typography-typography-h1: 500 2.5341081619262695rem/118.38484422541731% Lato;
-  --gcds-typography-typography-h2: 500 2.2525405883789062rem/122.08437060746162% Lato;
-  --gcds-typography-typography-h3: 500 2.00225830078125rem/124.85901539399482% Lato;
-  --gcds-typography-typography-h4: 500 1.77978515625rem/126.41975308641973% Lato;
-  --gcds-typography-typography-h5: 500 1.58203125rem/126.41975308641975% Lato;
-  --gcds-typography-typography-h6: 500 1.40625rem/124.44444444444444% Lato;
-  --gcds-typography-typography-label: 500 1.25rem/120% Noto Sans;
-  --gcds-typography-typography-hint: 400 1.1111111111111112rem/135% Noto Sans;
-  --gcds-typography-typography-text: 400 1.25rem/120% Noto Sans;
-  --gcds-typography-typography-paragraph: 400 1.25rem/150% Noto Sans;
+  --gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% Lato;
+  --gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% Lato;
+  --gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% Lato;
+  --gcds-font-h4: 700 1.77978515625rem/126.41975308641973% Lato;
+  --gcds-font-h5: 700 1.58203125rem/126.41975308641975% Lato;
+  --gcds-font-h6: 700 1.40625rem/124.44444444444444% Lato;
+  --gcds-font-label: 500 1.25rem/120% Noto Sans;
+  --gcds-font-caption: 400 1.1111111111111112rem/135% Noto Sans;
+  --gcds-font-text: 400 1.25rem/120% Noto Sans;
+  --gcds-font-long-text: 400 1.25rem/150% Noto Sans;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 20 Jan 2023 07:31:19 GMT
+ * Generated on Mon, 23 Jan 2023 19:32:32 GMT
  */
 
 :root {
@@ -411,11 +411,4 @@
   --gcds-verify-banner-text: #000000;
   --gcds-verify-banner-toggle-text: #26374a;
   --gcds-verify-banner-toggle-font-weight: 700;
-  --gcds-global-default-text: #000000;
-  --gcds-global-focus: #303fc3;
-  --gcds-global-active-text: #ffffff;
-  --gcds-global-active-background: #000000;
-  --gcds-global-disabled-background: #d6d9dd;
-  --gcds-global-disabled-text: #545961;
-  --gcds-global-destructive: #a62a1e;
 }

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 24 Jan 2023 19:18:21 GMT
+ * Generated on Tue, 24 Jan 2023 19:48:58 GMT
  */
 
 :root {
@@ -92,7 +92,7 @@
   --gcds-font-label: 500 1.25rem/120% Noto Sans;
   --gcds-font-caption: 400 1.1111111111111112rem/135% Noto Sans;
   --gcds-font-text: 400 1.25rem/120% Noto Sans;
-  --gcds-font-long-text: 400 1.25rem/150% Noto Sans;
+  --gcds-font-text-long: 400 1.25rem/150% Noto Sans;
   --gcds-alert-button-focus-background: #303fc3;
   --gcds-alert-button-focus-text: #ffffff;
   --gcds-alert-text: #000000;

--- a/config.js
+++ b/config.js
@@ -20,6 +20,18 @@ const traverseObj = (obj) => {
   return output;
 };
 
+StyleDictionary.registerTransform({
+  type: `value`,
+  name: `typography/font`,
+  transitive: true,
+  matcher: (token) => {
+    return token.attributes.category === 'typography';
+  },
+  transformer: (token) => {
+    return `${token.original.value.fontWeight} ${token.original.value.fontSize}/${token.original.value.lineHeight} ${token.original.value.fontFamily}`;
+  },
+});
+
 module.exports = {
   source: ['tokens/**/*.@(js|json)'],
   format: {
@@ -33,7 +45,15 @@ module.exports = {
   },
   platforms: {
     scss: {
-      transformGroup: 'scss',
+      transforms: [
+        'attribute/cti',
+        'name/cti/kebab',
+        'time/seconds',
+        'content/icon',
+        'size/rem',
+        'color/css',
+        'typography/font',
+      ],
       prefix: 'gcds',
       files: [
         {
@@ -44,7 +64,16 @@ module.exports = {
       output: true,
     },
     css: {
-      transformGroup: 'css',
+      //   transformGroup: 'css',
+      transforms: [
+        'attribute/cti',
+        'name/cti/kebab',
+        'time/seconds',
+        'content/icon',
+        'size/rem',
+        'color/css',
+        'typography/font',
+      ],
       prefix: 'gcds',
       files: [
         {
@@ -55,7 +84,6 @@ module.exports = {
       output: true,
     },
     figma: {
-      transforms: ['name/cti/kebab'],
       buildPath: 'build/',
       prefix: 'gcds',
       basePxFontSize: 20,

--- a/config.js
+++ b/config.js
@@ -25,7 +25,7 @@ StyleDictionary.registerTransform({
   name: `typography/font`,
   transitive: true,
   matcher: (token) => {
-    return token.attributes.category === 'typography';
+    return token.type === 'typography';
   },
   transformer: (token) => {
     return `${token.original.value.fontWeight} ${token.original.value.fontSize}/${token.original.value.lineHeight} ${token.original.value.fontFamily}`;

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -224,7 +224,7 @@ const font = {
     },
     type: 'typography',
   },
-  longText: {
+  textLong: {
     value: {
       fontFamily: '{fontFamilies.body}',
       fontWeight: '{fontWeights.regular}',

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -151,9 +151,6 @@ const font = {
       fontSize: '{fontSizes.h1}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   h2: {
     value: {
@@ -163,9 +160,6 @@ const font = {
       fontSize: '{fontSizes.h2}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   h3: {
     value: {
@@ -175,9 +169,6 @@ const font = {
       fontSize: '{fontSizes.h3}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   h4: {
     value: {
@@ -187,9 +178,6 @@ const font = {
       fontSize: '{fontSizes.h4}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   h5: {
     value: {
@@ -199,9 +187,6 @@ const font = {
       fontSize: '{fontSizes.h5}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   h6: {
     value: {
@@ -211,9 +196,6 @@ const font = {
       fontSize: '{fontSizes.h6}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   label: {
     value: {
@@ -223,9 +205,6 @@ const font = {
       fontSize: '{fontSizes.text}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   caption: {
     value: {
@@ -235,9 +214,6 @@ const font = {
       fontSize: '{fontSizes.caption}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   text: {
     value: {
@@ -247,9 +223,6 @@ const font = {
       fontSize: '{fontSizes.text}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
   longText: {
     value: {
@@ -259,9 +232,6 @@ const font = {
       fontSize: '{fontSizes.text}',
     },
     type: 'typography',
-    attributes: {
-      category: 'typography',
-    },
   },
 };
 

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -145,6 +145,131 @@ const lineHeights = {
   },
 };
 
+const typography = {
+  typography: {
+    h1: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h1}',
+        fontSize: '{fontSizes.h1}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    h2: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h2}',
+        fontSize: '{fontSizes.h2}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    h3: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h3}',
+        fontSize: '{fontSizes.h3}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    h4: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h4}',
+        fontSize: '{fontSizes.h4}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    h5: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h5}',
+        fontSize: '{fontSizes.h5}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    h6: {
+      value: {
+        fontFamily: '{fontFamilies.heading}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.h6}',
+        fontSize: '{fontSizes.h6}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    label: {
+      value: {
+        fontFamily: '{fontFamilies.body}',
+        fontWeight: '{fontWeights.medium}',
+        lineHeight: '{lineHeights.text}',
+        fontSize: '{fontSizes.text}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    hint: {
+      value: {
+        fontFamily: '{fontFamilies.body}',
+        fontWeight: '{fontWeights.regular}',
+        lineHeight: '{lineHeights.caption}',
+        fontSize: '{fontSizes.caption}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    text: {
+      value: {
+        fontFamily: '{fontFamilies.body}',
+        fontWeight: '{fontWeights.regular}',
+        lineHeight: '{lineHeights.text}',
+        fontSize: '{fontSizes.text}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+    paragraph: {
+      value: {
+        fontFamily: '{fontFamilies.body}',
+        fontWeight: '{fontWeights.regular}',
+        lineHeight: '150%',
+        fontSize: '{fontSizes.text}',
+      },
+      type: 'typography',
+      attributes: {
+        category: 'typography',
+      },
+    },
+  },
+};
+
 module.exports = {
   base,
   fontFamilies,

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -276,4 +276,5 @@ module.exports = {
   fontSizes,
   fontWeights,
   lineHeights,
+  typography,
 };

--- a/tokens/base/typography/base.js
+++ b/tokens/base/typography/base.js
@@ -1,17 +1,14 @@
 const base = {
   fontSize: {
     value: 1.25,
-    type: 'typography',
     comment: 'Sets base font size to 20px',
   },
   lineHeight: {
     value: 1.2,
-    type: 'typography',
     comment: 'Sets base line height to 24px',
   },
   scale: {
     value: 1.125,
-    type: 'typography',
   },
 };
 
@@ -145,127 +142,125 @@ const lineHeights = {
   },
 };
 
-const typography = {
-  typography: {
-    h1: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h1}',
-        fontSize: '{fontSizes.h1}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+const font = {
+  h1: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h1}',
+      fontSize: '{fontSizes.h1}',
     },
-    h2: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h2}',
-        fontSize: '{fontSizes.h2}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
     },
-    h3: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h3}',
-        fontSize: '{fontSizes.h3}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+  },
+  h2: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h2}',
+      fontSize: '{fontSizes.h2}',
     },
-    h4: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h4}',
-        fontSize: '{fontSizes.h4}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
     },
-    h5: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h5}',
-        fontSize: '{fontSizes.h5}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+  },
+  h3: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h3}',
+      fontSize: '{fontSizes.h3}',
     },
-    h6: {
-      value: {
-        fontFamily: '{fontFamilies.heading}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.h6}',
-        fontSize: '{fontSizes.h6}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
     },
-    label: {
-      value: {
-        fontFamily: '{fontFamilies.body}',
-        fontWeight: '{fontWeights.medium}',
-        lineHeight: '{lineHeights.text}',
-        fontSize: '{fontSizes.text}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+  },
+  h4: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h4}',
+      fontSize: '{fontSizes.h4}',
     },
-    hint: {
-      value: {
-        fontFamily: '{fontFamilies.body}',
-        fontWeight: '{fontWeights.regular}',
-        lineHeight: '{lineHeights.caption}',
-        fontSize: '{fontSizes.caption}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
     },
-    text: {
-      value: {
-        fontFamily: '{fontFamilies.body}',
-        fontWeight: '{fontWeights.regular}',
-        lineHeight: '{lineHeights.text}',
-        fontSize: '{fontSizes.text}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+  },
+  h5: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h5}',
+      fontSize: '{fontSizes.h5}',
     },
-    paragraph: {
-      value: {
-        fontFamily: '{fontFamilies.body}',
-        fontWeight: '{fontWeights.regular}',
-        lineHeight: '150%',
-        fontSize: '{fontSizes.text}',
-      },
-      type: 'typography',
-      attributes: {
-        category: 'typography',
-      },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
+    },
+  },
+  h6: {
+    value: {
+      fontFamily: '{fontFamilies.heading}',
+      fontWeight: '{fontWeights.bold}',
+      lineHeight: '{lineHeights.h6}',
+      fontSize: '{fontSizes.h6}',
+    },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
+    },
+  },
+  label: {
+    value: {
+      fontFamily: '{fontFamilies.body}',
+      fontWeight: '{fontWeights.medium}',
+      lineHeight: '{lineHeights.text}',
+      fontSize: '{fontSizes.text}',
+    },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
+    },
+  },
+  caption: {
+    value: {
+      fontFamily: '{fontFamilies.body}',
+      fontWeight: '{fontWeights.regular}',
+      lineHeight: '{lineHeights.caption}',
+      fontSize: '{fontSizes.caption}',
+    },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
+    },
+  },
+  text: {
+    value: {
+      fontFamily: '{fontFamilies.body}',
+      fontWeight: '{fontWeights.regular}',
+      lineHeight: '{lineHeights.text}',
+      fontSize: '{fontSizes.text}',
+    },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
+    },
+  },
+  longText: {
+    value: {
+      fontFamily: '{fontFamilies.body}',
+      fontWeight: '{fontWeights.regular}',
+      lineHeight: '150%',
+      fontSize: '{fontSizes.text}',
+    },
+    type: 'typography',
+    attributes: {
+      category: 'typography',
     },
   },
 };
@@ -276,5 +271,5 @@ module.exports = {
   fontSizes,
   fontWeights,
   lineHeights,
-  typography,
+  font,
 };


### PR DESCRIPTION
# Summary | Résumé

We have tokens for individual typography attributes, but we can do a bit more for Figma by creating text styles containing all attributes needed to compose an h1, h2, label, etc. 

These are a bit more opinion based, but they also are optional and don't interfere with individual props. They also provide a useful shortcut to compose typography.

For css, we can also compose a [font shorthand declaration](https://developer.mozilla.org/en-US/docs/Web/CSS/font). Which could be equally useful as utilities to apply everything at once. 