### PR TITLE
Exporting a plain json package for the documentation site.

### DIFF
--- a/build/docs/tokens.json
+++ b/build/docs/tokens.json
@@ -1,0 +1,10394 @@
+{
+  "brand": {
+    "default": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/base/brand/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-brand-default-text",
+        "attributes": {},
+        "path": [
+          "brand",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "value": "#303FC3",
+      "type": "color",
+      "filePath": "tokens/base/brand/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.blue.focus.value}",
+        "type": "color"
+      },
+      "name": "gcds-brand-focus",
+      "attributes": {},
+      "path": [
+        "brand",
+        "focus"
+      ]
+    },
+    "active": {
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/base/brand/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-brand-active-text",
+        "attributes": {},
+        "path": [
+          "brand",
+          "active",
+          "text"
+        ]
+      },
+      "background": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/base/brand/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-brand-active-background",
+        "attributes": {},
+        "path": [
+          "brand",
+          "active",
+          "background"
+        ]
+      }
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/base/brand/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-brand-disabled-background",
+        "attributes": {},
+        "path": [
+          "brand",
+          "disabled",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/base/brand/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.700.value}",
+          "type": "color"
+        },
+        "name": "gcds-brand-disabled-text",
+        "attributes": {},
+        "path": [
+          "brand",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "value": "#A62A1E",
+      "type": "color",
+      "filePath": "tokens/base/brand/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.red.700.value}",
+        "type": "color"
+      },
+      "name": "gcds-brand-destructive",
+      "attributes": {},
+      "path": [
+        "brand",
+        "destructive"
+      ]
+    }
+  },
+  "color": {
+    "blue": {
+      "100": {
+        "value": "#D7E5F5",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#D7E5F5",
+          "type": "color"
+        },
+        "name": "gcds-color-blue-100",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "100"
+        ]
+      },
+      "500": {
+        "value": "#6584A6",
+        "type": "color",
+        "comment": "Must contrast 3:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#6584A6",
+          "type": "color",
+          "comment": "Must contrast 3:1 with white"
+        },
+        "name": "gcds-color-blue-500",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "500"
+        ]
+      },
+      "700": {
+        "value": "#425A76",
+        "type": "color",
+        "comment": "Must contrast 7:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#425A76",
+          "type": "color",
+          "comment": "Must contrast 7:1 with white"
+        },
+        "name": "gcds-color-blue-700",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "700"
+        ]
+      },
+      "800": {
+        "value": "#31455C",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#31455C",
+          "type": "color"
+        },
+        "name": "gcds-color-blue-800",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "800"
+        ]
+      },
+      "900": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#26374A",
+          "type": "color"
+        },
+        "name": "gcds-color-blue-900",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "900"
+        ]
+      },
+      "focus": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#303FC3",
+          "type": "color"
+        },
+        "name": "gcds-color-blue-focus",
+        "attributes": {},
+        "path": [
+          "color",
+          "blue",
+          "focus"
+        ]
+      }
+    },
+    "grayscale": {
+      "0": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#FFF",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-0",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "0"
+        ]
+      },
+      "50": {
+        "value": "#F1F2F3",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#F1F2F3",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-50",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "50"
+        ]
+      },
+      "100": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#D6D9DD",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-100",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "100"
+        ]
+      },
+      "300": {
+        "value": "#A8ADB4",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#A8ADB4",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-300",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "300"
+        ]
+      },
+      "500": {
+        "value": "#7D828B",
+        "type": "color",
+        "comment": "Must contrast 3:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#7D828B",
+          "type": "color",
+          "comment": "Must contrast 3:1 with white"
+        },
+        "name": "gcds-color-grayscale-500",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "500"
+        ]
+      },
+      "700": {
+        "value": "#545961",
+        "type": "color",
+        "comment": "Must contrast 7:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#545961",
+          "type": "color",
+          "comment": "Must contrast 7:1 with white"
+        },
+        "name": "gcds-color-grayscale-700",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "700"
+        ]
+      },
+      "900": {
+        "value": "#2F3238",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#2F3238",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-900",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "900"
+        ]
+      },
+      "1000": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#000",
+          "type": "color"
+        },
+        "name": "gcds-color-grayscale-1000",
+        "attributes": {},
+        "path": [
+          "color",
+          "grayscale",
+          "1000"
+        ]
+      }
+    },
+    "green": {
+      "100": {
+        "value": "#E6F6EC",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#E6F6EC",
+          "type": "color"
+        },
+        "name": "gcds-color-green-100",
+        "attributes": {},
+        "path": [
+          "color",
+          "green",
+          "100"
+        ]
+      },
+      "500": {
+        "value": "#289F58",
+        "type": "color",
+        "comment": "Must contrast 3:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#289F58",
+          "type": "color",
+          "comment": "Must contrast 3:1 with white"
+        },
+        "name": "gcds-color-green-500",
+        "attributes": {},
+        "path": [
+          "color",
+          "green",
+          "500"
+        ]
+      },
+      "700": {
+        "value": "#03662A",
+        "type": "color",
+        "comment": "Must contrast 7:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#03662A",
+          "type": "color",
+          "comment": "Must contrast 7:1 with white"
+        },
+        "name": "gcds-color-green-700",
+        "attributes": {},
+        "path": [
+          "color",
+          "green",
+          "700"
+        ]
+      }
+    },
+    "red": {
+      "100": {
+        "value": "#FBDDDA",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#FBDDDA",
+          "type": "color"
+        },
+        "name": "gcds-color-red-100",
+        "attributes": {},
+        "path": [
+          "color",
+          "red",
+          "100"
+        ]
+      },
+      "500": {
+        "value": "#C24438",
+        "type": "color",
+        "comment": "Must contrast 3:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#C24438",
+          "type": "color",
+          "comment": "Must contrast 3:1 with white"
+        },
+        "name": "gcds-color-red-500",
+        "attributes": {},
+        "path": [
+          "color",
+          "red",
+          "500"
+        ]
+      },
+      "700": {
+        "value": "#A62A1E",
+        "type": "color",
+        "comment": "Must contrast 7:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#A62A1E",
+          "type": "color",
+          "comment": "Must contrast 7:1 with white"
+        },
+        "name": "gcds-color-red-700",
+        "attributes": {},
+        "path": [
+          "color",
+          "red",
+          "700"
+        ]
+      },
+      "900": {
+        "value": "#822117",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#822117",
+          "type": "color"
+        },
+        "name": "gcds-color-red-900",
+        "attributes": {},
+        "path": [
+          "color",
+          "red",
+          "900"
+        ]
+      },
+      "flag": {
+        "value": "#FF0000",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#FF0000",
+          "type": "color"
+        },
+        "name": "gcds-color-red-flag",
+        "attributes": {},
+        "path": [
+          "color",
+          "red",
+          "flag"
+        ]
+      }
+    },
+    "yellow": {
+      "100": {
+        "value": "#FAEDD1",
+        "type": "color",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#FAEDD1",
+          "type": "color"
+        },
+        "name": "gcds-color-yellow-100",
+        "attributes": {},
+        "path": [
+          "color",
+          "yellow",
+          "100"
+        ]
+      },
+      "500": {
+        "value": "#B3800F",
+        "type": "color",
+        "comment": "Must contrast 3:1 with white",
+        "filePath": "tokens/base/color/base.json",
+        "isSource": true,
+        "original": {
+          "value": "#B3800F",
+          "type": "color",
+          "comment": "Must contrast 3:1 with white"
+        },
+        "name": "gcds-color-yellow-500",
+        "attributes": {},
+        "path": [
+          "color",
+          "yellow",
+          "500"
+        ]
+      }
+    }
+  },
+  "container": {
+    "xs": {
+      "value": "20rem",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "20rem",
+        "type": "sizing"
+      },
+      "name": "gcds-container-xs",
+      "attributes": {},
+      "path": [
+        "container",
+        "xs"
+      ]
+    },
+    "sm": {
+      "value": "30rem",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "30rem",
+        "type": "sizing"
+      },
+      "name": "gcds-container-sm",
+      "attributes": {},
+      "path": [
+        "container",
+        "sm"
+      ]
+    },
+    "md": {
+      "value": "48rem",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "48rem",
+        "type": "sizing"
+      },
+      "name": "gcds-container-md",
+      "attributes": {},
+      "path": [
+        "container",
+        "md"
+      ]
+    },
+    "lg": {
+      "value": "64rem",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "64rem",
+        "type": "sizing"
+      },
+      "name": "gcds-container-lg",
+      "attributes": {},
+      "path": [
+        "container",
+        "lg"
+      ]
+    },
+    "xl": {
+      "value": "75rem",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "75rem",
+        "type": "sizing"
+      },
+      "name": "gcds-container-xl",
+      "attributes": {},
+      "path": [
+        "container",
+        "xl"
+      ]
+    },
+    "full": {
+      "value": "100%",
+      "type": "sizing",
+      "filePath": "tokens/base/container/base.json",
+      "isSource": true,
+      "original": {
+        "value": "100%",
+        "type": "sizing"
+      },
+      "name": "gcds-container-full",
+      "attributes": {},
+      "path": [
+        "container",
+        "full"
+      ]
+    }
+  },
+  "spacing": {
+    "50": {
+      "value": "0.1875rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "0.1875rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-50",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "50"
+      ]
+    },
+    "100": {
+      "value": "0.375rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "0.375rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-100",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "100"
+      ]
+    },
+    "150": {
+      "value": "0.5625rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "0.5625rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-150",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "150"
+      ]
+    },
+    "200": {
+      "value": "0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "0.75rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-200",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "200"
+      ]
+    },
+    "250": {
+      "value": "0.9375rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "0.9375rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-250",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "250"
+      ]
+    },
+    "300": {
+      "value": "1.125rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.125rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-300",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "300"
+      ]
+    },
+    "400": {
+      "value": "1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.5rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-400",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "400"
+      ]
+    },
+    "450": {
+      "value": "2.25rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "2.25rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-450",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "450"
+      ]
+    },
+    "500": {
+      "value": "3rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "3rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-500",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "500"
+      ]
+    },
+    "550": {
+      "value": "3.75rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "3.75rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-550",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "550"
+      ]
+    },
+    "600": {
+      "value": "4.5rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "4.5rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-600",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "600"
+      ]
+    },
+    "700": {
+      "value": "6rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "6rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-700",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "700"
+      ]
+    },
+    "800": {
+      "value": "7.5rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "7.5rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-800",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "800"
+      ]
+    },
+    "900": {
+      "value": "9rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "9rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-900",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "900"
+      ]
+    },
+    "1000": {
+      "value": "10.5rem",
+      "type": "spacing",
+      "filePath": "tokens/base/spacing/base.js",
+      "isSource": true,
+      "original": {
+        "value": "10.5rem",
+        "type": "spacing"
+      },
+      "name": "gcds-spacing-1000",
+      "attributes": {},
+      "path": [
+        "spacing",
+        "1000"
+      ]
+    }
+  },
+  "base": {
+    "fontSize": {
+      "value": 1.25,
+      "comment": "Sets base font size to 20px",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": 1.25,
+        "comment": "Sets base font size to 20px"
+      },
+      "name": "gcds-base-font-size",
+      "attributes": {},
+      "path": [
+        "base",
+        "fontSize"
+      ]
+    },
+    "lineHeight": {
+      "value": 1.2,
+      "comment": "Sets base line height to 24px",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": 1.2,
+        "comment": "Sets base line height to 24px"
+      },
+      "name": "gcds-base-line-height",
+      "attributes": {},
+      "path": [
+        "base",
+        "lineHeight"
+      ]
+    },
+    "scale": {
+      "value": 1.125,
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": 1.125
+      },
+      "name": "gcds-base-scale",
+      "attributes": {},
+      "path": [
+        "base",
+        "scale"
+      ]
+    }
+  },
+  "fontFamilies": {
+    "heading": {
+      "value": "Lato",
+      "type": "fontFamilies",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "Lato",
+        "type": "fontFamilies"
+      },
+      "name": "gcds-font-families-heading",
+      "attributes": {},
+      "path": [
+        "fontFamilies",
+        "heading"
+      ]
+    },
+    "body": {
+      "value": "Noto Sans",
+      "type": "fontFamilies",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "Noto Sans",
+        "type": "fontFamilies"
+      },
+      "name": "gcds-font-families-body",
+      "attributes": {},
+      "path": [
+        "fontFamilies",
+        "body"
+      ]
+    },
+    "monospace": {
+      "value": "Menlo",
+      "type": "fontFamilies",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "Menlo",
+        "type": "fontFamilies"
+      },
+      "name": "gcds-font-families-monospace",
+      "attributes": {},
+      "path": [
+        "fontFamilies",
+        "monospace"
+      ]
+    },
+    "icons": {
+      "value": "FontAwesome",
+      "type": "fontFamilies",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "FontAwesome",
+        "type": "fontFamilies"
+      },
+      "name": "gcds-font-families-icons",
+      "attributes": {},
+      "path": [
+        "fontFamilies",
+        "icons"
+      ]
+    }
+  },
+  "fontSizes": {
+    "caption": {
+      "value": "1.1111111111111112rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.1111111111111112rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-caption",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "caption"
+      ]
+    },
+    "text": {
+      "value": "1.25rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.25rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-text",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "text"
+      ]
+    },
+    "h6": {
+      "value": "1.40625rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.40625rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h6",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h6"
+      ]
+    },
+    "h5": {
+      "value": "1.58203125rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.58203125rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h5",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h5"
+      ]
+    },
+    "h4": {
+      "value": "1.77978515625rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "1.77978515625rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h4",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h4"
+      ]
+    },
+    "h3": {
+      "value": "2.00225830078125rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "2.00225830078125rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h3",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h3"
+      ]
+    },
+    "h2": {
+      "value": "2.2525405883789062rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "2.2525405883789062rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h2",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h2"
+      ]
+    },
+    "h1": {
+      "value": "2.5341081619262695rem",
+      "type": "fontSizes",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "2.5341081619262695rem",
+        "type": "fontSizes"
+      },
+      "name": "gcds-font-sizes-h1",
+      "attributes": {},
+      "path": [
+        "fontSizes",
+        "h1"
+      ]
+    }
+  },
+  "fontWeights": {
+    "light": {
+      "value": "300",
+      "type": "fontWeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "300",
+        "type": "fontWeights"
+      },
+      "name": "gcds-font-weights-light",
+      "attributes": {},
+      "path": [
+        "fontWeights",
+        "light"
+      ]
+    },
+    "regular": {
+      "value": "400",
+      "type": "fontWeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "400",
+        "type": "fontWeights"
+      },
+      "name": "gcds-font-weights-regular",
+      "attributes": {},
+      "path": [
+        "fontWeights",
+        "regular"
+      ]
+    },
+    "medium": {
+      "value": "500",
+      "type": "fontWeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "500",
+        "type": "fontWeights"
+      },
+      "name": "gcds-font-weights-medium",
+      "attributes": {},
+      "path": [
+        "fontWeights",
+        "medium"
+      ]
+    },
+    "semibold": {
+      "value": "600",
+      "type": "fontWeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "600",
+        "type": "fontWeights"
+      },
+      "name": "gcds-font-weights-semibold",
+      "attributes": {},
+      "path": [
+        "fontWeights",
+        "semibold"
+      ]
+    },
+    "bold": {
+      "value": "700",
+      "type": "fontWeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "700",
+        "type": "fontWeights"
+      },
+      "name": "gcds-font-weights-bold",
+      "attributes": {},
+      "path": [
+        "fontWeights",
+        "bold"
+      ]
+    }
+  },
+  "lineHeights": {
+    "caption": {
+      "value": "135%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "135%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-caption",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "caption"
+      ]
+    },
+    "text": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "120%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-text",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "text"
+      ]
+    },
+    "h6": {
+      "value": "124.44444444444444%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "124.44444444444444%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h6",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h6"
+      ]
+    },
+    "h5": {
+      "value": "126.41975308641975%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "126.41975308641975%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h5",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h5"
+      ]
+    },
+    "h4": {
+      "value": "126.41975308641973%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "126.41975308641973%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h4",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h4"
+      ]
+    },
+    "h3": {
+      "value": "124.85901539399482%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "124.85901539399482%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h3",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h3"
+      ]
+    },
+    "h2": {
+      "value": "122.08437060746162%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "122.08437060746162%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h2",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h2"
+      ]
+    },
+    "h1": {
+      "value": "118.38484422541731%",
+      "type": "lineHeights",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": "118.38484422541731%",
+        "type": "lineHeights"
+      },
+      "name": "gcds-line-heights-h1",
+      "attributes": {},
+      "path": [
+        "lineHeights",
+        "h1"
+      ]
+    }
+  },
+  "font": {
+    "h1": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "118.38484422541731%",
+        "fontSize": "2.5341081619262695rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h1}",
+          "fontSize": "{fontSizes.h1}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h1",
+      "attributes": {},
+      "path": [
+        "font",
+        "h1"
+      ]
+    },
+    "h2": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "122.08437060746162%",
+        "fontSize": "2.2525405883789062rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h2}",
+          "fontSize": "{fontSizes.h2}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h2",
+      "attributes": {},
+      "path": [
+        "font",
+        "h2"
+      ]
+    },
+    "h3": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "124.85901539399482%",
+        "fontSize": "2.00225830078125rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h3}",
+          "fontSize": "{fontSizes.h3}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h3",
+      "attributes": {},
+      "path": [
+        "font",
+        "h3"
+      ]
+    },
+    "h4": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "126.41975308641973%",
+        "fontSize": "1.77978515625rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h4}",
+          "fontSize": "{fontSizes.h4}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h4",
+      "attributes": {},
+      "path": [
+        "font",
+        "h4"
+      ]
+    },
+    "h5": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "126.41975308641975%",
+        "fontSize": "1.58203125rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h5}",
+          "fontSize": "{fontSizes.h5}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h5",
+      "attributes": {},
+      "path": [
+        "font",
+        "h5"
+      ]
+    },
+    "h6": {
+      "value": {
+        "fontFamily": "Lato",
+        "fontWeight": "700",
+        "lineHeight": "124.44444444444444%",
+        "fontSize": "1.40625rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h6}",
+          "fontSize": "{fontSizes.h6}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-h6",
+      "attributes": {},
+      "path": [
+        "font",
+        "h6"
+      ]
+    },
+    "label": {
+      "value": {
+        "fontFamily": "Noto Sans",
+        "fontWeight": "500",
+        "lineHeight": "120%",
+        "fontSize": "1.25rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.medium}",
+          "lineHeight": "{lineHeights.text}",
+          "fontSize": "{fontSizes.text}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-label",
+      "attributes": {},
+      "path": [
+        "font",
+        "label"
+      ]
+    },
+    "caption": {
+      "value": {
+        "fontFamily": "Noto Sans",
+        "fontWeight": "400",
+        "lineHeight": "135%",
+        "fontSize": "1.1111111111111112rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "{lineHeights.caption}",
+          "fontSize": "{fontSizes.caption}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-caption",
+      "attributes": {},
+      "path": [
+        "font",
+        "caption"
+      ]
+    },
+    "text": {
+      "value": {
+        "fontFamily": "Noto Sans",
+        "fontWeight": "400",
+        "lineHeight": "120%",
+        "fontSize": "1.25rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "{lineHeights.text}",
+          "fontSize": "{fontSizes.text}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-text",
+      "attributes": {},
+      "path": [
+        "font",
+        "text"
+      ]
+    },
+    "textLong": {
+      "value": {
+        "fontFamily": "Noto Sans",
+        "fontWeight": "400",
+        "lineHeight": "150%",
+        "fontSize": "1.25rem"
+      },
+      "type": "typography",
+      "filePath": "tokens/base/typography/base.js",
+      "isSource": true,
+      "original": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "150%",
+          "fontSize": "{fontSizes.text}"
+        },
+        "type": "typography"
+      },
+      "name": "gcds-font-text-long",
+      "attributes": {},
+      "path": [
+        "font",
+        "textLong"
+      ]
+    }
+  },
+  "alert": {
+    "border": {
+      "width": {
+        "value": "0.375rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "borderWidth"
+        },
+        "name": "gcds-alert-border-width",
+        "attributes": {},
+        "path": [
+          "alert",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "button": {
+      "border": {
+        "radius": {
+          "value": "0.375rem",
+          "type": "borderRadius",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.100.value}",
+            "type": "borderRadius"
+          },
+          "name": "gcds-alert-button-border-radius",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": ".125rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": ".125rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-alert-button-border-width",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "active": {
+        "border": {
+          "color": {
+            "value": "#000",
+            "type": "color",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{color.grayscale.1000.value}",
+              "type": "color"
+            },
+            "name": "gcds-alert-button-active-border-color",
+            "attributes": {},
+            "path": [
+              "alert",
+              "button",
+              "active",
+              "border",
+              "color"
+            ]
+          }
+        }
+      },
+      "default": {
+        "background": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-alert-button-default-background",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "default",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#000",
+          "type": "color",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.1000.value}",
+            "type": "color"
+          },
+          "name": "gcds-alert-button-default-text",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "default",
+            "text"
+          ]
+        }
+      },
+      "focus": {
+        "background": {
+          "value": "#303FC3",
+          "type": "color",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.focus.value}",
+            "type": "color"
+          },
+          "name": "gcds-alert-button-focus-background",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "focus",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-alert-button-focus-text",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "focus",
+            "text"
+          ]
+        }
+      },
+      "icon": {
+        "padding": {
+          "value": "0.75rem",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.200.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-button-icon-padding",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "icon",
+            "padding"
+          ]
+        },
+        "widthAndHeight": {
+          "value": "1.125rem",
+          "type": "sizing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.300.value}",
+            "type": "sizing"
+          },
+          "name": "gcds-alert-button-icon-width-and-height",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "icon",
+            "widthAndHeight"
+          ]
+        }
+      },
+      "margin": {
+        "value": "0 0 0 0.9375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.250.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-alert-button-margin",
+        "attributes": {},
+        "path": [
+          "alert",
+          "button",
+          "margin"
+        ]
+      },
+      "mobile": {
+        "margin": {
+          "value": "0.9375rem 0 0",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.250.value} 0 0",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-button-mobile-margin",
+          "attributes": {},
+          "path": [
+            "alert",
+            "button",
+            "mobile",
+            "margin"
+          ]
+        }
+      }
+    },
+    "container": {
+      "xs": {
+        "value": "20rem",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xs.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-xs",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "xs"
+        ]
+      },
+      "sm": {
+        "value": "30rem",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.sm.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-sm",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "sm"
+        ]
+      },
+      "md": {
+        "value": "48rem",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.md.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-md",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "md"
+        ]
+      },
+      "lg": {
+        "value": "64rem",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.lg.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-lg",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "lg"
+        ]
+      },
+      "xl": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-xl",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "xl"
+        ]
+      },
+      "full": {
+        "value": "100%",
+        "type": "sizing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.full.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-alert-container-full",
+        "attributes": {},
+        "path": [
+          "alert",
+          "container",
+          "full"
+        ]
+      }
+    },
+    "content": {
+      "heading": {
+        "font": {
+          "family": {
+            "value": "Lato",
+            "type": "fontFamilies",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{fontFamilies.heading.value}",
+              "type": "fontFamilies"
+            },
+            "name": "gcds-alert-content-heading-font-family",
+            "attributes": {},
+            "path": [
+              "alert",
+              "content",
+              "heading",
+              "font",
+              "family"
+            ]
+          },
+          "size": {
+            "value": "1.58203125rem",
+            "type": "fontSizes",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{fontSizes.h5.value}",
+              "type": "fontSizes"
+            },
+            "name": "gcds-alert-content-heading-font-size",
+            "attributes": {},
+            "path": [
+              "alert",
+              "content",
+              "heading",
+              "font",
+              "size"
+            ]
+          },
+          "weight": {
+            "value": "700",
+            "type": "fontWeights",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{fontWeights.bold.value}",
+              "type": "fontWeights"
+            },
+            "name": "gcds-alert-content-heading-font-weight",
+            "attributes": {},
+            "path": [
+              "alert",
+              "content",
+              "heading",
+              "font",
+              "weight"
+            ]
+          }
+        },
+        "lineHeight": {
+          "value": "126.41975308641975%",
+          "type": "lineHeights",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{lineHeights.h5.value}",
+            "type": "lineHeights"
+          },
+          "name": "gcds-alert-content-heading-line-height",
+          "attributes": {},
+          "path": [
+            "alert",
+            "content",
+            "heading",
+            "lineHeight"
+          ]
+        },
+        "margin": {
+          "value": "0.1875rem 0 0.5625rem",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value} 0 {spacing.150.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-content-heading-margin",
+          "attributes": {},
+          "path": [
+            "alert",
+            "content",
+            "heading",
+            "margin"
+          ]
+        },
+        "mobile": {
+          "margin": {
+            "value": "0 0 0.5625rem",
+            "type": "spacing",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "0 0 {spacing.150.value}",
+              "type": "spacing"
+            },
+            "name": "gcds-alert-content-heading-mobile-margin",
+            "attributes": {},
+            "path": [
+              "alert",
+              "content",
+              "heading",
+              "mobile",
+              "margin"
+            ]
+          }
+        }
+      },
+      "slotted": {
+        "list": {
+          "margin": {
+            "value": "1.5rem",
+            "type": "spacing",
+            "filePath": "tokens/components/alert/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{spacing.400.value}",
+              "type": "spacing"
+            },
+            "name": "gcds-alert-content-slotted-list-margin",
+            "attributes": {},
+            "path": [
+              "alert",
+              "content",
+              "slotted",
+              "list",
+              "margin"
+            ]
+          }
+        },
+        "margin": {
+          "value": "0.5625rem",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.150.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-content-slotted-margin",
+          "attributes": {},
+          "path": [
+            "alert",
+            "content",
+            "slotted",
+            "margin"
+          ]
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-alert-font-family",
+        "attributes": {},
+        "path": [
+          "alert",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-alert-font-size",
+        "attributes": {},
+        "path": [
+          "alert",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-alert-font-weight",
+        "attributes": {},
+        "path": [
+          "alert",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "icon": {
+      "font": {
+        "size": {
+          "value": "2.25rem",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.450.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-icon-font-size",
+          "attributes": {},
+          "path": [
+            "alert",
+            "icon",
+            "font",
+            "size"
+          ]
+        }
+      },
+      "margin": {
+        "value": "0 0.9375rem 0 0",
+        "type": "spacing",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 {spacing.250.value} 0 0",
+          "type": "spacing"
+        },
+        "name": "gcds-alert-icon-margin",
+        "attributes": {},
+        "path": [
+          "alert",
+          "icon",
+          "margin"
+        ]
+      },
+      "mobile": {
+        "margin": {
+          "value": "0 0 0.9375rem",
+          "type": "spacing",
+          "filePath": "tokens/components/alert/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 {spacing.250.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-alert-icon-mobile-margin",
+          "attributes": {},
+          "path": [
+            "alert",
+            "icon",
+            "mobile",
+            "margin"
+          ]
+        }
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/alert/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-alert-line-height",
+      "attributes": {},
+      "path": [
+        "alert",
+        "lineHeight"
+      ]
+    },
+    "padding": {
+      "value": "0.75rem 0.9375rem",
+      "type": "spacing",
+      "filePath": "tokens/components/alert/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.200.value} {spacing.250.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-alert-padding",
+      "attributes": {},
+      "path": [
+        "alert",
+        "padding"
+      ]
+    },
+    "text": {
+      "value": "#000",
+      "type": "color",
+      "filePath": "tokens/components/alert/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.grayscale.1000.value}",
+        "type": "color"
+      },
+      "name": "gcds-alert-text",
+      "attributes": {},
+      "path": [
+        "alert",
+        "text"
+      ]
+    },
+    "destructive": {
+      "background": {
+        "value": "#FBDDDA",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.red.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-destructive-background",
+        "attributes": {},
+        "path": [
+          "alert",
+          "destructive",
+          "background"
+        ]
+      },
+      "icon": {
+        "value": "#C24438",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.red.500.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-destructive-icon",
+        "attributes": {},
+        "path": [
+          "alert",
+          "destructive",
+          "icon"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-destructive-text",
+        "attributes": {},
+        "path": [
+          "alert",
+          "destructive",
+          "text"
+        ]
+      }
+    },
+    "info": {
+      "background": {
+        "value": "#D7E5F5",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-info-background",
+        "attributes": {},
+        "path": [
+          "alert",
+          "info",
+          "background"
+        ]
+      },
+      "icon": {
+        "value": "#6584A6",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.500.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-info-icon",
+        "attributes": {},
+        "path": [
+          "alert",
+          "info",
+          "icon"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-info-text",
+        "attributes": {},
+        "path": [
+          "alert",
+          "info",
+          "text"
+        ]
+      }
+    },
+    "success": {
+      "background": {
+        "value": "#E6F6EC",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.green.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-success-background",
+        "attributes": {},
+        "path": [
+          "alert",
+          "success",
+          "background"
+        ]
+      },
+      "icon": {
+        "value": "#289F58",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.green.500.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-success-icon",
+        "attributes": {},
+        "path": [
+          "alert",
+          "success",
+          "icon"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-success-text",
+        "attributes": {},
+        "path": [
+          "alert",
+          "success",
+          "text"
+        ]
+      }
+    },
+    "warning": {
+      "background": {
+        "value": "#FAEDD1",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.yellow.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-warning-background",
+        "attributes": {},
+        "path": [
+          "alert",
+          "warning",
+          "background"
+        ]
+      },
+      "icon": {
+        "value": "#B3800F",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.yellow.500.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-warning-icon",
+        "attributes": {},
+        "path": [
+          "alert",
+          "warning",
+          "icon"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/alert/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-alert-warning-text",
+        "attributes": {},
+        "path": [
+          "alert",
+          "warning",
+          "text"
+        ]
+      }
+    }
+  },
+  "breadcrumbs": {
+    "default": {
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-breadcrumbs-default-text",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "background": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-breadcrumbs-focus-background",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "focus",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-breadcrumbs-focus-text",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "focus",
+          "text"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-breadcrumbs-font-family",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-breadcrumbs-font-size",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-breadcrumbs-font-weight",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "hover": {
+      "text": {
+        "value": "#425A76",
+        "type": "color",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.700.value}",
+          "type": "color"
+        },
+        "name": "gcds-breadcrumbs-hover-text",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "hover",
+          "text"
+        ]
+      }
+    },
+    "item": {
+      "arrow": {
+        "top": {
+          "value": "0.1875rem",
+          "type": "spacing",
+          "filePath": "tokens/components/breadcrumbs/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-breadcrumbs-item-arrow-top",
+          "attributes": {},
+          "path": [
+            "breadcrumbs",
+            "item",
+            "arrow",
+            "top"
+          ]
+        },
+        "left": {
+          "value": "0.1875rem",
+          "type": "spacing",
+          "filePath": "tokens/components/breadcrumbs/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-breadcrumbs-item-arrow-left",
+          "attributes": {},
+          "path": [
+            "breadcrumbs",
+            "item",
+            "arrow",
+            "left"
+          ]
+        }
+      },
+      "firstChild": {
+        "margin": {
+          "value": "0 0 0 -1.5rem",
+          "type": "spacing",
+          "filePath": "tokens/components/breadcrumbs/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 0 -{spacing.400.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-breadcrumbs-item-first-child-margin",
+          "attributes": {},
+          "path": [
+            "breadcrumbs",
+            "item",
+            "firstChild",
+            "margin"
+          ]
+        }
+      },
+      "link": {
+        "padding": {
+          "value": "0.1875rem",
+          "type": "spacing",
+          "filePath": "tokens/components/breadcrumbs/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-breadcrumbs-item-link-padding",
+          "attributes": {},
+          "path": [
+            "breadcrumbs",
+            "item",
+            "link",
+            "padding"
+          ]
+        }
+      },
+      "margin": {
+        "value": "0.75rem 0",
+        "type": "spacing",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value} 0",
+          "type": "spacing"
+        },
+        "name": "gcds-breadcrumbs-item-margin",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "item",
+          "margin"
+        ]
+      },
+      "padding": {
+        "value": "0 0 0 1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/breadcrumbs/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-breadcrumbs-item-padding",
+        "attributes": {},
+        "path": [
+          "breadcrumbs",
+          "item",
+          "padding"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/breadcrumbs/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-breadcrumbs-line-height",
+      "attributes": {},
+      "path": [
+        "breadcrumbs",
+        "lineHeight"
+      ]
+    }
+  },
+  "button": {
+    "border": {
+      "radius": {
+        "value": "0.375rem",
+        "type": "border",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "border"
+        },
+        "name": "gcds-button-border-radius",
+        "attributes": {},
+        "path": [
+          "button",
+          "border",
+          "radius"
+        ]
+      },
+      "width": {
+        "value": "0.125rem",
+        "type": "border",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0.125rem",
+          "type": "border"
+        },
+        "name": "gcds-button-border-width",
+        "attributes": {},
+        "path": [
+          "button",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "destructive": {
+      "default": {
+        "background": {
+          "value": "#A62A1E",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.red.700.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-destructive-default-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "destructive",
+            "default",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-destructive-default-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "destructive",
+            "default",
+            "text"
+          ]
+        }
+      },
+      "hover": {
+        "background": {
+          "value": "#822117",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.red.900.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-destructive-hover-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "destructive",
+            "hover",
+            "background"
+          ]
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-button-font-family",
+        "attributes": {},
+        "path": [
+          "button",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-button-font-size",
+        "attributes": {},
+        "path": [
+          "button",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-button-font-weight",
+        "attributes": {},
+        "path": [
+          "button",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/button/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-button-line-height",
+      "attributes": {},
+      "path": [
+        "button",
+        "lineHeight"
+      ]
+    },
+    "padding": {
+      "value": "1.125rem 0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/button/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.300.value} {spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-button-padding",
+      "attributes": {},
+      "path": [
+        "button",
+        "padding"
+      ]
+    },
+    "primary": {
+      "default": {
+        "background": {
+          "value": "#26374A",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.900.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-primary-default-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "primary",
+            "default",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-primary-default-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "primary",
+            "default",
+            "text"
+          ]
+        }
+      },
+      "hover": {
+        "background": {
+          "value": "#425A76",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.700.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-primary-hover-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "primary",
+            "hover",
+            "background"
+          ]
+        }
+      }
+    },
+    "secondary": {
+      "default": {
+        "background": {
+          "value": "transparent",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "transparent",
+            "type": "color"
+          },
+          "name": "gcds-button-secondary-default-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "secondary",
+            "default",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#26374A",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.900.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-secondary-default-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "secondary",
+            "default",
+            "text"
+          ]
+        }
+      },
+      "hover": {
+        "background": {
+          "value": "#D7E5F5",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.100.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-secondary-hover-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "secondary",
+            "hover",
+            "background"
+          ]
+        }
+      },
+      "active": {
+        "background": {
+          "value": "#D7E5F5",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.100.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-secondary-active-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "secondary",
+            "active",
+            "background"
+          ]
+        }
+      }
+    },
+    "shared": {
+      "active": {
+        "background": {
+          "value": "#000",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.active.background.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-active-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "active",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.active.text.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-active-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "active",
+            "text"
+          ]
+        }
+      },
+      "focus": {
+        "background": {
+          "value": "#303FC3",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.focus.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-focus-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "focus",
+            "background"
+          ]
+        },
+        "outline": {
+          "width": {
+            "value": "0.1875rem",
+            "type": "other",
+            "filePath": "tokens/components/button/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{spacing.50.value}",
+              "type": "other"
+            },
+            "name": "gcds-button-shared-focus-outline-width",
+            "attributes": {},
+            "path": [
+              "button",
+              "shared",
+              "focus",
+              "outline",
+              "width"
+            ]
+          }
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-focus-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "focus",
+            "text"
+          ]
+        }
+      },
+      "disabled": {
+        "background": {
+          "value": "#D6D9DD",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.disabled.background.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-disabled-background",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "disabled",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#545961",
+          "type": "color",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.disabled.text.value}",
+            "type": "color"
+          },
+          "name": "gcds-button-shared-disabled-text",
+          "attributes": {},
+          "path": [
+            "button",
+            "shared",
+            "disabled",
+            "text"
+          ]
+        }
+      }
+    },
+    "skip": {
+      "top": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-button-skip-top",
+        "attributes": {},
+        "path": [
+          "button",
+          "skip",
+          "top"
+        ]
+      }
+    },
+    "small": {
+      "font": {
+        "size": {
+          "value": "80%",
+          "type": "fontSizes",
+          "filePath": "tokens/components/button/base.json",
+          "isSource": true,
+          "original": {
+            "value": "80%",
+            "type": "fontSizes"
+          },
+          "name": "gcds-button-small-font-size",
+          "attributes": {},
+          "path": [
+            "button",
+            "small",
+            "font",
+            "size"
+          ]
+        }
+      },
+      "padding": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/button/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-button-small-padding",
+        "attributes": {},
+        "path": [
+          "button",
+          "small",
+          "padding"
+        ]
+      }
+    }
+  },
+  "checkbox": {
+    "check": {
+      "border": {
+        "width": {
+          "value": "0.3125rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.3125rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-checkbox-check-border-width",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "check",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "height": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-checkbox-check-height",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "check",
+          "height"
+        ]
+      },
+      "left": {
+        "value": "1rem",
+        "type": "spacing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "1rem",
+          "type": "spacing"
+        },
+        "name": "gcds-checkbox-check-left",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "check",
+          "left"
+        ]
+      },
+      "top": {
+        "value": "-0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "-{spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-checkbox-check-top",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "check",
+          "top"
+        ]
+      },
+      "width": {
+        "value": "0.9375rem",
+        "type": "sizing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.250.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-checkbox-check-width",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "check",
+          "width"
+        ]
+      }
+    },
+    "default": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-default-text",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "default",
+          "text"
+        ]
+      },
+      "hint": {
+        "value": "#2F3238",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-default-hint",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "default",
+          "hint"
+        ]
+      }
+    },
+    "destructive": {
+      "text": {
+        "value": "#A62A1E",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.destructive.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-destructive-text",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "destructive",
+          "text"
+        ]
+      }
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-disabled-background",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "disabled",
+          "background"
+        ]
+      },
+      "border": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-disabled-border",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "disabled",
+          "border"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-disabled-text",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "error": {
+      "padding": {
+        "value": "0 0 0 3.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.550.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-checkbox-error-padding",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "error",
+          "padding"
+        ]
+      }
+    },
+    "focus": {
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-focus-text",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "focus",
+          "text"
+        ]
+      },
+      "outline": {
+        "width": {
+          "value": "0.1875rem",
+          "type": "other",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "other"
+          },
+          "name": "gcds-checkbox-focus-outline-width",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "focus",
+            "outline",
+            "width"
+          ]
+        }
+      },
+      "shadow": {
+        "color": {
+          "value": "#FFF",
+          "type": "other",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "other"
+          },
+          "name": "gcds-checkbox-focus-shadow-color",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "focus",
+            "shadow",
+            "color"
+          ]
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-checkbox-font-family",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-checkbox-font-size",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-checkbox-font-weight",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "input": {
+      "border": {
+        "radius": {
+          "value": "0.1875rem",
+          "type": "border",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "border"
+          },
+          "name": "gcds-checkbox-input-border-radius",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "input",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": "0.125rem",
+          "type": "border",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.125rem",
+            "type": "border"
+          },
+          "name": "gcds-checkbox-input-border-width",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "input",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "heightAndWidth": {
+        "value": "3rem",
+        "type": "sizing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-checkbox-input-height-and-width",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "input",
+          "heightAndWidth"
+        ]
+      }
+    },
+    "hint": {
+      "font": {
+        "size": {
+          "value": "1.1111111111111112rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/checkbox/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.caption.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-checkbox-hint-font-size",
+          "attributes": {},
+          "path": [
+            "checkbox",
+            "hint",
+            "font",
+            "size"
+          ]
+        }
+      },
+      "lineHeight": {
+        "value": "135%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.caption.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-checkbox-hint-line-height",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "hint",
+          "lineHeight"
+        ]
+      },
+      "text": {
+        "value": "#2F3238",
+        "type": "color",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-checkbox-hint-text",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "hint",
+          "text"
+        ]
+      }
+    },
+    "label": {
+      "padding": {
+        "value": "0 0 0 3.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/checkbox/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.550.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-checkbox-label-padding",
+        "attributes": {},
+        "path": [
+          "checkbox",
+          "label",
+          "padding"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/checkbox/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-checkbox-line-height",
+      "attributes": {},
+      "path": [
+        "checkbox",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "2.25rem 0 1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/components/checkbox/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.450.value} 0 {spacing.400.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-checkbox-margin",
+      "attributes": {},
+      "path": [
+        "checkbox",
+        "margin"
+      ]
+    },
+    "top": {
+      "value": "-0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/checkbox/base.json",
+      "isSource": true,
+      "original": {
+        "value": "-{spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-checkbox-top",
+      "attributes": {},
+      "path": [
+        "checkbox",
+        "top"
+      ]
+    }
+  },
+  "date-modified": {
+    "description": {
+      "margin": {
+        "value": "0 0 0 0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/date-modified/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-date-modified-description-margin",
+        "attributes": {},
+        "path": [
+          "date-modified",
+          "description",
+          "margin"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/date-modified/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-date-modified-font-family",
+        "attributes": {},
+        "path": [
+          "date-modified",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/date-modified/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-date-modified-font-size",
+        "attributes": {},
+        "path": [
+          "date-modified",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/date-modified/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-date-modified-font-weight",
+        "attributes": {},
+        "path": [
+          "date-modified",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/date-modified/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-date-modified-line-height",
+      "attributes": {},
+      "path": [
+        "date-modified",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "3rem 0 0",
+      "type": "spacing",
+      "filePath": "tokens/components/date-modified/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.500.value} 0 0",
+        "type": "spacing"
+      },
+      "name": "gcds-date-modified-margin",
+      "attributes": {},
+      "path": [
+        "date-modified",
+        "margin"
+      ]
+    }
+  },
+  "details": {
+    "default": {
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-default-text",
+        "attributes": {},
+        "path": [
+          "details",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "active": {
+      "background": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.active.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-active-background",
+        "attributes": {},
+        "path": [
+          "details",
+          "active",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.active.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-active-text",
+        "attributes": {},
+        "path": [
+          "details",
+          "active",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "background": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-focus-background",
+        "attributes": {},
+        "path": [
+          "details",
+          "focus",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-focus-text",
+        "attributes": {},
+        "path": [
+          "details",
+          "focus",
+          "text"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-details-font-family",
+        "attributes": {},
+        "path": [
+          "details",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-details-font-size",
+        "attributes": {},
+        "path": [
+          "details",
+          "font",
+          "size"
+        ]
+      },
+      "sizeSmall": {
+        "value": "1.1111111111111112rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.caption.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-details-font-size-small",
+        "attributes": {},
+        "path": [
+          "details",
+          "font",
+          "sizeSmall"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-details-font-weight",
+        "attributes": {},
+        "path": [
+          "details",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "hover": {
+      "text": {
+        "value": "#31455C",
+        "type": "color",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.800.value}",
+          "type": "color"
+        },
+        "name": "gcds-details-hover-text",
+        "attributes": {},
+        "path": [
+          "details",
+          "hover",
+          "text"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/details/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-details-line-height",
+      "attributes": {},
+      "path": [
+        "details",
+        "lineHeight"
+      ]
+    },
+    "panel": {
+      "border": {
+        "color": {
+          "value": "#7D828B",
+          "type": "border",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.500.value}",
+            "type": "border"
+          },
+          "name": "gcds-details-panel-border-color",
+          "attributes": {},
+          "path": [
+            "details",
+            "panel",
+            "border",
+            "color"
+          ]
+        },
+        "width": {
+          "value": "0.375rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.100.value}",
+            "type": "borderWidth"
+          },
+          "name": "gcds-details-panel-border-width",
+          "attributes": {},
+          "path": [
+            "details",
+            "panel",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "margin": {
+        "value": "0.375rem 0 0 0",
+        "type": "spacing",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value} 0 0 0",
+          "type": "spacing"
+        },
+        "name": "gcds-details-panel-margin",
+        "attributes": {},
+        "path": [
+          "details",
+          "panel",
+          "margin"
+        ]
+      },
+      "padding": {
+        "value": "0.5625rem 2.25rem",
+        "type": "spacing",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.150.value} {spacing.450.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-details-panel-padding",
+        "attributes": {},
+        "path": [
+          "details",
+          "panel",
+          "padding"
+        ]
+      },
+      "slotted": {
+        "margin": {
+          "value": "1.5rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.400.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-panel-slotted-margin",
+          "attributes": {},
+          "path": [
+            "details",
+            "panel",
+            "slotted",
+            "margin"
+          ]
+        }
+      }
+    },
+    "summary": {
+      "arrow": {
+        "borderLeft": {
+          "value": "0.9375rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.250.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-summary-arrow-border-left",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "arrow",
+            "borderLeft"
+          ]
+        },
+        "borderTopBottom": {
+          "value": "0.5625rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.150.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-summary-arrow-border-top-bottom",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "arrow",
+            "borderTopBottom"
+          ]
+        },
+        "left": {
+          "value": "0.375rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.100.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-summary-arrow-left",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "arrow",
+            "left"
+          ]
+        },
+        "top": {
+          "value": "0.5625rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.150.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-summary-arrow-top",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "arrow",
+            "top"
+          ]
+        }
+      },
+      "border": {
+        "width": {
+          "value": "0.0625rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.0625rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-details-summary-border-width",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "padding": {
+        "value": "0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/details/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-details-summary-padding",
+        "attributes": {},
+        "path": [
+          "details",
+          "summary",
+          "padding"
+        ]
+      },
+      "text": {
+        "margin": {
+          "value": "0 0 0 2.25rem",
+          "type": "spacing",
+          "filePath": "tokens/components/details/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 0 {spacing.450.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-details-summary-text-margin",
+          "attributes": {},
+          "path": [
+            "details",
+            "summary",
+            "text",
+            "margin"
+          ]
+        }
+      }
+    }
+  },
+  "error-message": {
+    "background": {
+      "value": "#FBDDDA",
+      "type": "color",
+      "filePath": "tokens/components/error-message/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.red.100.value}",
+        "type": "color"
+      },
+      "name": "gcds-error-message-background",
+      "attributes": {},
+      "path": [
+        "error-message",
+        "background"
+      ]
+    },
+    "border": {
+      "color": {
+        "value": "#A62A1E",
+        "type": "border",
+        "filePath": "tokens/components/error-message/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.destructive.value}",
+          "type": "border"
+        },
+        "name": "gcds-error-message-border-color",
+        "attributes": {},
+        "path": [
+          "error-message",
+          "border",
+          "color"
+        ]
+      },
+      "width": {
+        "value": ".125rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/error-message/base.json",
+        "isSource": true,
+        "original": {
+          "value": ".125rem",
+          "type": "borderWidth"
+        },
+        "name": "gcds-error-message-border-width",
+        "attributes": {},
+        "path": [
+          "error-message",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/error-message/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-error-message-font-family",
+        "attributes": {},
+        "path": [
+          "error-message",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/error-message/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-error-message-font-size",
+        "attributes": {},
+        "path": [
+          "error-message",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/error-message/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-error-message-font-weight",
+        "attributes": {},
+        "path": [
+          "error-message",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/error-message/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-error-message-line-height",
+      "attributes": {},
+      "path": [
+        "error-message",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 1.125rem",
+      "type": "spacing",
+      "filePath": "tokens/components/error-message/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.300.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-error-message-margin",
+      "attributes": {},
+      "path": [
+        "error-message",
+        "margin"
+      ]
+    },
+    "padding": {
+      "value": "0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/error-message/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-error-message-padding",
+      "attributes": {},
+      "path": [
+        "error-message",
+        "padding"
+      ]
+    },
+    "text": {
+      "value": "#000",
+      "type": "color",
+      "filePath": "tokens/components/error-message/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.grayscale.1000.value}",
+        "type": "color"
+      },
+      "name": "gcds-error-message-text",
+      "attributes": {},
+      "path": [
+        "error-message",
+        "text"
+      ]
+    }
+  },
+  "fieldset": {
+    "default": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-fieldset-default-text",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "value": "#A62A1E",
+      "type": "color",
+      "filePath": "tokens/components/fieldset/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{brand.destructive.value}",
+        "type": "color"
+      },
+      "name": "gcds-fieldset-destructive",
+      "attributes": {},
+      "path": [
+        "fieldset",
+        "destructive"
+      ]
+    },
+    "disabled": {
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-fieldset-disabled-text",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "value": "#303FC3",
+      "type": "color",
+      "filePath": "tokens/components/fieldset/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{brand.focus.value}",
+        "type": "color"
+      },
+      "name": "gcds-fieldset-focus",
+      "attributes": {},
+      "path": [
+        "fieldset",
+        "focus"
+      ]
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-fieldset-font-family",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-fieldset-font-size",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "600",
+        "type": "fontWeights",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.semibold.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-fieldset-font-weight",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "legend": {
+      "margin": {
+        "value": "0 0 0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/fieldset/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 {spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-fieldset-legend-margin",
+        "attributes": {},
+        "path": [
+          "fieldset",
+          "legend",
+          "margin"
+        ]
+      },
+      "required": {
+        "margin": {
+          "value": "0 0 0 0.375rem",
+          "type": "spacing",
+          "filePath": "tokens/components/fieldset/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 0 {spacing.100.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-fieldset-legend-required-margin",
+          "attributes": {},
+          "path": [
+            "fieldset",
+            "legend",
+            "required",
+            "margin"
+          ]
+        }
+      }
+    }
+  },
+  "file-uploader": {
+    "button": {
+      "background": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-button-background",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "button",
+          "background"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "0.375rem",
+          "type": "borderRadius",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.100.value}",
+            "type": "borderRadius"
+          },
+          "name": "gcds-file-uploader-button-border-radius",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "button",
+            "border",
+            "radius"
+          ]
+        },
+        "width": {
+          "value": ".125rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": ".125rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-file-uploader-button-border-width",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "button",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "fontWeight": {
+        "value": "500",
+        "type": "fontWeights",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.medium.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-file-uploader-button-font-weight",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "button",
+          "fontWeight"
+        ]
+      },
+      "outline": {
+        "width": {
+          "value": "0.1875rem",
+          "type": "other",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "other"
+          },
+          "name": "gcds-file-uploader-button-outline-width",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "button",
+            "outline",
+            "width"
+          ]
+        }
+      },
+      "padding": {
+        "value": "1.125rem 0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value} {spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-file-uploader-button-padding",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "button",
+          "padding"
+        ]
+      },
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-button-text",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "button",
+          "text"
+        ]
+      }
+    },
+    "default": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-default-text",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "background": {
+        "value": "#FBDDDA",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.red.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-destructive-background",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "destructive",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#A62A1E",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.destructive.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-destructive-text",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "destructive",
+          "text"
+        ]
+      }
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-disabled-background",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "disabled",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-disabled-text",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-file-uploader-font-family",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-file-uploader-font-size",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-file-uploader-font-weight",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "file": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-file-background",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "file",
+          "background"
+        ]
+      },
+      "border": {
+        "radius": {
+          "value": "3rem",
+          "type": "borderRadius",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.500.value}",
+            "type": "borderRadius"
+          },
+          "name": "gcds-file-uploader-file-border-radius",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "border",
+            "radius"
+          ]
+        }
+      },
+      "icon": {
+        "default": {
+          "value": "#C24438",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.red.500.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-file-icon-default",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "icon",
+            "default"
+          ]
+        },
+        "hover": {
+          "value": "#822117",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.red.900.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-file-icon-hover",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "icon",
+            "hover"
+          ]
+        },
+        "active": {
+          "value": "#000",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.1000.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-file-icon-active",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "icon",
+            "active"
+          ]
+        }
+      },
+      "margin": {
+        "value": "0.75rem 0 0",
+        "type": "spacing",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value} 0 0",
+          "type": "spacing"
+        },
+        "name": "gcds-file-uploader-file-margin",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "file",
+          "margin"
+        ]
+      },
+      "marginFirstOfType": {
+        "value": "1.125rem 0 0",
+        "type": "spacing",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value} 0 0",
+          "type": "spacing"
+        },
+        "name": "gcds-file-uploader-file-margin-first-of-type",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "file",
+          "marginFirstOfType"
+        ]
+      },
+      "maxWidth": {
+        "value": "30rem",
+        "type": "sizing",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.sm.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-file-uploader-file-max-width",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "file",
+          "maxWidth"
+        ]
+      },
+      "outline": {
+        "offset": {
+          "value": ".125rem",
+          "type": "other",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": ".125rem",
+            "type": "other"
+          },
+          "name": "gcds-file-uploader-file-outline-offset",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "outline",
+            "offset"
+          ]
+        },
+        "width": {
+          "value": "0.1875rem",
+          "type": "other",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "other"
+          },
+          "name": "gcds-file-uploader-file-outline-width",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "file",
+            "outline",
+            "width"
+          ]
+        }
+      },
+      "padding": {
+        "value": "0.9375rem 1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.250.value} {spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-file-uploader-file-padding",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "file",
+          "padding"
+        ]
+      }
+    },
+    "focus": {
+      "button": {
+        "background": {
+          "value": "#303FC3",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.focus.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-focus-button-background",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "focus",
+            "button",
+            "background"
+          ]
+        },
+        "shadow": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-focus-button-shadow",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "focus",
+            "button",
+            "shadow"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/file-uploader/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-file-uploader-focus-button-text",
+          "attributes": {},
+          "path": [
+            "file-uploader",
+            "focus",
+            "button",
+            "text"
+          ]
+        }
+      },
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/file-uploader/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-file-uploader-focus-text",
+        "attributes": {},
+        "path": [
+          "file-uploader",
+          "focus",
+          "text"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/file-uploader/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-file-uploader-line-height",
+      "attributes": {},
+      "path": [
+        "file-uploader",
+        "lineHeight"
+      ]
+    }
+  },
+  "footer": {
+    "container": {
+      "margin": {
+        "value": "0 auto",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 auto",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-container-margin",
+        "attributes": {},
+        "path": [
+          "footer",
+          "container",
+          "margin"
+        ]
+      },
+      "width": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-footer-container-width",
+        "attributes": {},
+        "path": [
+          "footer",
+          "container",
+          "width"
+        ]
+      }
+    },
+    "contextual": {
+      "background": {
+        "value": "#31455C",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.800.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-contextual-background",
+        "attributes": {},
+        "path": [
+          "footer",
+          "contextual",
+          "background"
+        ]
+      },
+      "padding": {
+        "value": "1.125rem 0",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value} 0",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-contextual-padding",
+        "attributes": {},
+        "path": [
+          "footer",
+          "contextual",
+          "padding"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-contextual-text",
+        "attributes": {},
+        "path": [
+          "footer",
+          "contextual",
+          "text"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-footer-font-family",
+        "attributes": {},
+        "path": [
+          "footer",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "85%",
+        "type": "fontSizes",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "85%",
+          "type": "fontSizes"
+        },
+        "name": "gcds-footer-font-size",
+        "attributes": {},
+        "path": [
+          "footer",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-footer-font-weight",
+        "attributes": {},
+        "path": [
+          "footer",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/footer/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-footer-line-height",
+      "attributes": {},
+      "path": [
+        "footer",
+        "lineHeight"
+      ]
+    },
+    "list": {
+      "gridGap": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-list-grid-gap",
+        "attributes": {},
+        "path": [
+          "footer",
+          "list",
+          "gridGap"
+        ]
+      },
+      "padding": {
+        "value": "0",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-list-padding",
+        "attributes": {},
+        "path": [
+          "footer",
+          "list",
+          "padding"
+        ]
+      }
+    },
+    "listitem": {
+      "margin": {
+        "value": "0 0 1.125rem",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 {spacing.300.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-listitem-margin",
+        "attributes": {},
+        "path": [
+          "footer",
+          "listitem",
+          "margin"
+        ]
+      }
+    },
+    "main": {
+      "background": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-main-background",
+        "attributes": {},
+        "path": [
+          "footer",
+          "main",
+          "background"
+        ]
+      },
+      "govnav": {
+        "padding": {
+          "value": "1.125rem 0",
+          "type": "spacing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.300.value} 0",
+            "type": "spacing"
+          },
+          "name": "gcds-footer-main-govnav-padding",
+          "attributes": {},
+          "path": [
+            "footer",
+            "main",
+            "govnav",
+            "padding"
+          ]
+        }
+      },
+      "nav": {
+        "first": {
+          "after": {
+            "border": {
+              "color": {
+                "value": "#FFF",
+                "type": "border",
+                "filePath": "tokens/components/footer/base.json",
+                "isSource": true,
+                "original": {
+                  "value": "{color.grayscale.0.value}",
+                  "type": "border"
+                },
+                "name": "gcds-footer-main-nav-first-after-border-color",
+                "attributes": {},
+                "path": [
+                  "footer",
+                  "main",
+                  "nav",
+                  "first",
+                  "after",
+                  "border",
+                  "color"
+                ]
+              },
+              "width": {
+                "value": "0.375rem",
+                "type": "borderWidth",
+                "filePath": "tokens/components/footer/base.json",
+                "isSource": true,
+                "original": {
+                  "value": "{spacing.100.value}",
+                  "type": "borderWidth"
+                },
+                "name": "gcds-footer-main-nav-first-after-border-width",
+                "attributes": {},
+                "path": [
+                  "footer",
+                  "main",
+                  "nav",
+                  "first",
+                  "after",
+                  "border",
+                  "width"
+                ]
+              }
+            },
+            "width": {
+              "value": "2.25rem",
+              "type": "sizing",
+              "filePath": "tokens/components/footer/base.json",
+              "isSource": true,
+              "original": {
+                "value": "{spacing.450.value}",
+                "type": "sizing"
+              },
+              "name": "gcds-footer-main-nav-first-after-width",
+              "attributes": {},
+              "path": [
+                "footer",
+                "main",
+                "nav",
+                "first",
+                "after",
+                "width"
+              ]
+            }
+          }
+        }
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-main-text",
+        "attributes": {},
+        "path": [
+          "footer",
+          "main",
+          "text"
+        ]
+      },
+      "themenav": {
+        "padding": {
+          "value": "0.75rem 0 1.125rem",
+          "type": "spacing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.200.value} 0 {spacing.300.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-footer-main-themenav-padding",
+          "attributes": {},
+          "path": [
+            "footer",
+            "main",
+            "themenav",
+            "padding"
+          ]
+        }
+      }
+    },
+    "sub": {
+      "active": {
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.active.text.value}",
+            "type": "color"
+          },
+          "name": "gcds-footer-sub-active-text",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "active",
+            "text"
+          ]
+        },
+        "background": {
+          "value": "#000",
+          "type": "color",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.active.background.value}",
+            "type": "color"
+          },
+          "name": "gcds-footer-sub-active-background",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "active",
+            "background"
+          ]
+        }
+      },
+      "background": {
+        "value": "#F1F2F3",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.50.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-sub-background",
+        "attributes": {},
+        "path": [
+          "footer",
+          "sub",
+          "background"
+        ]
+      },
+      "focus": {
+        "background": {
+          "value": "#303FC3",
+          "type": "color",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{brand.focus.value}",
+            "type": "color"
+          },
+          "name": "gcds-footer-sub-focus-background",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "focus",
+            "background"
+          ]
+        },
+        "text": {
+          "value": "#FFF",
+          "type": "color",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "color"
+          },
+          "name": "gcds-footer-sub-focus-text",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "focus",
+            "text"
+          ]
+        }
+      },
+      "gridGap": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-footer-sub-grid-gap",
+        "attributes": {},
+        "path": [
+          "footer",
+          "sub",
+          "gridGap"
+        ]
+      },
+      "hover": {
+        "text": {
+          "value": "#31455C",
+          "type": "color",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.800.value}",
+            "type": "color"
+          },
+          "name": "gcds-footer-sub-hover-text",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "hover",
+            "text"
+          ]
+        }
+      },
+      "listitem": {
+        "before": {
+          "margin": {
+            "value": "0 1.125rem",
+            "type": "spacing",
+            "filePath": "tokens/components/footer/base.json",
+            "isSource": true,
+            "original": {
+              "value": "0 {spacing.300.value}",
+              "type": "spacing"
+            },
+            "name": "gcds-footer-sub-listitem-before-margin",
+            "attributes": {},
+            "path": [
+              "footer",
+              "sub",
+              "listitem",
+              "before",
+              "margin"
+            ]
+          }
+        }
+      },
+      "nav": {
+        "padding": {
+          "value": "3rem 0",
+          "type": "spacing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.500.value} 0",
+            "type": "spacing"
+          },
+          "name": "gcds-footer-sub-nav-padding",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "nav",
+            "padding"
+          ]
+        }
+      },
+      "signature": {
+        "lg": {
+          "width": {
+            "value": "10.937rem",
+            "type": "sizing",
+            "filePath": "tokens/components/footer/base.json",
+            "isSource": true,
+            "original": {
+              "value": "10.937rem",
+              "type": "sizing"
+            },
+            "name": "gcds-footer-sub-signature-lg-width",
+            "attributes": {},
+            "path": [
+              "footer",
+              "sub",
+              "signature",
+              "lg",
+              "width"
+            ]
+          },
+          "minWidth": {
+            "value": "auto",
+            "type": "sizing",
+            "filePath": "tokens/components/footer/base.json",
+            "isSource": true,
+            "original": {
+              "value": "auto",
+              "type": "sizing"
+            },
+            "name": "gcds-footer-sub-signature-lg-min-width",
+            "attributes": {},
+            "path": [
+              "footer",
+              "sub",
+              "signature",
+              "lg",
+              "minWidth"
+            ]
+          }
+        },
+        "margin": {
+          "value": "0 0 1.5rem auto",
+          "type": "spacing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 {spacing.400.value} auto",
+            "type": "spacing"
+          },
+          "name": "gcds-footer-sub-signature-margin",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "signature",
+            "margin"
+          ]
+        }
+      },
+      "md": {
+        "width": {
+          "value": "7rem",
+          "type": "sizing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "7rem",
+            "type": "sizing"
+          },
+          "name": "gcds-footer-sub-md-width",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "md",
+            "width"
+          ]
+        }
+      },
+      "sm": {
+        "width": {
+          "value": "100%",
+          "type": "sizing",
+          "filePath": "tokens/components/footer/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{container.full.value}",
+            "type": "sizing"
+          },
+          "name": "gcds-footer-sub-sm-width",
+          "attributes": {},
+          "path": [
+            "footer",
+            "sub",
+            "sm",
+            "width"
+          ]
+        }
+      },
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/footer/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-footer-sub-text",
+        "attributes": {},
+        "path": [
+          "footer",
+          "sub",
+          "text"
+        ]
+      }
+    }
+  },
+  "grid": {
+    "container": {
+      "xs": {
+        "value": "20rem",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xs.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-xs",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "xs"
+        ]
+      },
+      "sm": {
+        "value": "30rem",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.sm.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-sm",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "sm"
+        ]
+      },
+      "md": {
+        "value": "48rem",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.md.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-md",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "md"
+        ]
+      },
+      "lg": {
+        "value": "64rem",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.lg.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-lg",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "lg"
+        ]
+      },
+      "xl": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-xl",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "xl"
+        ]
+      },
+      "full": {
+        "value": "100%",
+        "type": "sizing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.full.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-grid-container-full",
+        "attributes": {},
+        "path": [
+          "grid",
+          "container",
+          "full"
+        ]
+      }
+    },
+    "gap": {
+      "50": {
+        "value": "0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-50",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "50"
+        ]
+      },
+      "100": {
+        "value": "0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-100",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "100"
+        ]
+      },
+      "150": {
+        "value": "0.5625rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.150.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-150",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "150"
+        ]
+      },
+      "200": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-200",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "200"
+        ]
+      },
+      "250": {
+        "value": "0.9375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.250.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-250",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "250"
+        ]
+      },
+      "300": {
+        "value": "1.125rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-300",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-400",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "400"
+        ]
+      },
+      "450": {
+        "value": "2.25rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.450.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-450",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "450"
+        ]
+      },
+      "500": {
+        "value": "3rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-500",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "500"
+        ]
+      },
+      "550": {
+        "value": "3.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.550.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-550",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "550"
+        ]
+      },
+      "600": {
+        "value": "4.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.600.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-600",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "600"
+        ]
+      },
+      "700": {
+        "value": "6rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.700.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-700",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "700"
+        ]
+      },
+      "800": {
+        "value": "7.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.800.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-800",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "800"
+        ]
+      },
+      "900": {
+        "value": "9rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.900.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-900",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "900"
+        ]
+      },
+      "1000": {
+        "value": "10.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/grid/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.1000.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-grid-gap-1000",
+        "attributes": {},
+        "path": [
+          "grid",
+          "gap",
+          "1000"
+        ]
+      }
+    }
+  },
+  "header": {
+    "brand": {
+      "border": {
+        "color": {
+          "value": "#26374A",
+          "type": "border",
+          "filePath": "tokens/components/header/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.900.value}",
+            "type": "border"
+          },
+          "name": "gcds-header-brand-border-color",
+          "attributes": {},
+          "path": [
+            "header",
+            "brand",
+            "border",
+            "color"
+          ]
+        },
+        "width": {
+          "value": "0.1875rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/header/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.1875rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-header-brand-border-width",
+          "attributes": {},
+          "path": [
+            "header",
+            "brand",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "grid": {
+        "gap": {
+          "value": "0.75rem",
+          "type": "spacing",
+          "filePath": "tokens/components/header/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.200.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-header-brand-grid-gap",
+          "attributes": {},
+          "path": [
+            "header",
+            "brand",
+            "grid",
+            "gap"
+          ]
+        }
+      },
+      "margin": {
+        "value": "1.125rem 0 0",
+        "type": "spacing",
+        "filePath": "tokens/components/header/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value} 0 0",
+          "type": "spacing"
+        },
+        "name": "gcds-header-brand-margin",
+        "attributes": {},
+        "path": [
+          "header",
+          "brand",
+          "margin"
+        ]
+      },
+      "padding": {
+        "value": "0 0 0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/header/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 {spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-header-brand-padding",
+        "attributes": {},
+        "path": [
+          "header",
+          "brand",
+          "padding"
+        ]
+      },
+      "search": {
+        "width": {
+          "value": "30rem",
+          "type": "sizing",
+          "filePath": "tokens/components/header/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{container.sm.value}",
+            "type": "sizing"
+          },
+          "name": "gcds-header-brand-search-width",
+          "attributes": {},
+          "path": [
+            "header",
+            "brand",
+            "search",
+            "width"
+          ]
+        }
+      },
+      "toggle": {
+        "padding": {
+          "value": "0 1.125rem",
+          "type": "spacing",
+          "filePath": "tokens/components/header/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 {spacing.300.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-header-brand-toggle-padding",
+          "attributes": {},
+          "path": [
+            "header",
+            "brand",
+            "toggle",
+            "padding"
+          ]
+        }
+      }
+    },
+    "container": {
+      "maxWidth": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/header/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-header-container-max-width",
+        "attributes": {},
+        "path": [
+          "header",
+          "container",
+          "maxWidth"
+        ]
+      }
+    },
+    "margin": {
+      "value": "0 0 0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/header/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-header-margin",
+      "attributes": {},
+      "path": [
+        "header",
+        "margin"
+      ]
+    },
+    "topnav": {
+      "top": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/header/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-header-topnav-top",
+        "attributes": {},
+        "path": [
+          "header",
+          "topnav",
+          "top"
+        ]
+      }
+    }
+  },
+  "hint": {
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/hint/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-hint-font-family",
+        "attributes": {},
+        "path": [
+          "hint",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/hint/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-hint-font-size",
+        "attributes": {},
+        "path": [
+          "hint",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/hint/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-hint-font-weight",
+        "attributes": {},
+        "path": [
+          "hint",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/hint/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-hint-line-height",
+      "attributes": {},
+      "path": [
+        "hint",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/hint/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-hint-margin",
+      "attributes": {},
+      "path": [
+        "hint",
+        "margin"
+      ]
+    }
+  },
+  "icon": {
+    "font": {
+      "family": {
+        "value": "FontAwesome",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.icons.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-icon-font-family",
+        "attributes": {},
+        "path": [
+          "icon",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "xs": {
+          "value": "1.1111111111111112rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/icon/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.caption.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-icon-font-size-xs",
+          "attributes": {},
+          "path": [
+            "icon",
+            "font",
+            "size",
+            "xs"
+          ]
+        },
+        "sm": {
+          "value": "1.25rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/icon/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.text.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-icon-font-size-sm",
+          "attributes": {},
+          "path": [
+            "icon",
+            "font",
+            "size",
+            "sm"
+          ]
+        },
+        "md": {
+          "value": "1.58203125rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/icon/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.h5.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-icon-font-size-md",
+          "attributes": {},
+          "path": [
+            "icon",
+            "font",
+            "size",
+            "md"
+          ]
+        },
+        "lg": {
+          "value": "2.00225830078125rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/icon/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.h3.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-icon-font-size-lg",
+          "attributes": {},
+          "path": [
+            "icon",
+            "font",
+            "size",
+            "lg"
+          ]
+        },
+        "xl": {
+          "value": "2.5341081619262695rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/icon/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.h1.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-icon-font-size-xl",
+          "attributes": {},
+          "path": [
+            "icon",
+            "font",
+            "size",
+            "xl"
+          ]
+        }
+      }
+    },
+    "lineHeight": {
+      "xs": {
+        "value": "135%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.caption.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-icon-line-height-xs",
+        "attributes": {},
+        "path": [
+          "icon",
+          "lineHeight",
+          "xs"
+        ]
+      },
+      "sm": {
+        "value": "120%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.text.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-icon-line-height-sm",
+        "attributes": {},
+        "path": [
+          "icon",
+          "lineHeight",
+          "sm"
+        ]
+      },
+      "md": {
+        "value": "126.41975308641975%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.h5.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-icon-line-height-md",
+        "attributes": {},
+        "path": [
+          "icon",
+          "lineHeight",
+          "md"
+        ]
+      },
+      "lg": {
+        "value": "124.85901539399482%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.h3.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-icon-line-height-lg",
+        "attributes": {},
+        "path": [
+          "icon",
+          "lineHeight",
+          "lg"
+        ]
+      },
+      "xl": {
+        "value": "118.38484422541731%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.h1.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-icon-line-height-xl",
+        "attributes": {},
+        "path": [
+          "icon",
+          "lineHeight",
+          "xl"
+        ]
+      }
+    },
+    "margin": {
+      "50": {
+        "value": "0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-50",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "50"
+        ]
+      },
+      "100": {
+        "value": "0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-100",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "100"
+        ]
+      },
+      "150": {
+        "value": "0.5625rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.150.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-150",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "150"
+        ]
+      },
+      "200": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-200",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "200"
+        ]
+      },
+      "250": {
+        "value": "0.9375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.250.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-250",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "250"
+        ]
+      },
+      "300": {
+        "value": "1.125rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-300",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "300"
+        ]
+      },
+      "400": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-400",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "400"
+        ]
+      },
+      "450": {
+        "value": "2.25rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.450.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-450",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "450"
+        ]
+      },
+      "500": {
+        "value": "3rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-500",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "500"
+        ]
+      },
+      "550": {
+        "value": "3.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.550.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-550",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "550"
+        ]
+      },
+      "600": {
+        "value": "4.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.600.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-600",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "600"
+        ]
+      },
+      "700": {
+        "value": "6rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.700.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-700",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "700"
+        ]
+      },
+      "800": {
+        "value": "7.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.800.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-800",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "800"
+        ]
+      },
+      "900": {
+        "value": "9rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.900.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-900",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "900"
+        ]
+      },
+      "1000": {
+        "value": "10.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/icon/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.1000.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-icon-margin-1000",
+        "attributes": {},
+        "path": [
+          "icon",
+          "margin",
+          "1000"
+        ]
+      }
+    }
+  },
+  "input": {
+    "border": {
+      "radius": {
+        "value": "0.1875rem",
+        "type": "borderRadius",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "borderRadius"
+        },
+        "name": "gcds-input-border-radius",
+        "attributes": {},
+        "path": [
+          "input",
+          "border",
+          "radius"
+        ]
+      },
+      "width": {
+        "value": ".125rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": ".125rem",
+          "type": "borderWidth"
+        },
+        "name": "gcds-input-border-width",
+        "attributes": {},
+        "path": [
+          "input",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "default": {
+      "background": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-default-background",
+        "attributes": {},
+        "path": [
+          "input",
+          "default",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-default-text",
+        "attributes": {},
+        "path": [
+          "input",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "value": "#A62A1E",
+      "type": "color",
+      "filePath": "tokens/components/input/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{brand.destructive.value}",
+        "type": "color"
+      },
+      "name": "gcds-input-destructive",
+      "attributes": {},
+      "path": [
+        "input",
+        "destructive"
+      ]
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-disabled-background",
+        "attributes": {},
+        "path": [
+          "input",
+          "disabled",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-disabled-text",
+        "attributes": {},
+        "path": [
+          "input",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-focus-text",
+        "attributes": {},
+        "path": [
+          "input",
+          "focus",
+          "text"
+        ]
+      },
+      "shadow": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-input-focus-shadow",
+        "attributes": {},
+        "path": [
+          "input",
+          "focus",
+          "shadow"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-input-font-family",
+        "attributes": {},
+        "path": [
+          "input",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-input-font-size",
+        "attributes": {},
+        "path": [
+          "input",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-input-font-weight",
+        "attributes": {},
+        "path": [
+          "input",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/input/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-input-line-height",
+      "attributes": {},
+      "path": [
+        "input",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/components/input/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.400.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-input-margin",
+      "attributes": {},
+      "path": [
+        "input",
+        "margin"
+      ]
+    },
+    "minWidthAndHeight": {
+      "value": "3rem",
+      "type": "sizing",
+      "filePath": "tokens/components/input/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.500.value}",
+        "type": "sizing"
+      },
+      "name": "gcds-input-min-width-and-height",
+      "attributes": {},
+      "path": [
+        "input",
+        "minWidthAndHeight"
+      ]
+    },
+    "outline": {
+      "width": {
+        "value": "0.1875rem",
+        "type": "other",
+        "filePath": "tokens/components/input/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "other"
+        },
+        "name": "gcds-input-outline-width",
+        "attributes": {},
+        "path": [
+          "input",
+          "outline",
+          "width"
+        ]
+      }
+    },
+    "padding": {
+      "value": "0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/input/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-input-padding",
+      "attributes": {},
+      "path": [
+        "input",
+        "padding"
+      ]
+    }
+  },
+  "label": {
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/label/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-label-font-family",
+        "attributes": {},
+        "path": [
+          "label",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/label/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-label-font-size",
+        "attributes": {},
+        "path": [
+          "label",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "500",
+        "type": "fontWeights",
+        "filePath": "tokens/components/label/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.medium.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-label-font-weight",
+        "attributes": {},
+        "path": [
+          "label",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/label/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-label-line-height",
+      "attributes": {},
+      "path": [
+        "label",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 0.375rem",
+      "type": "spacing",
+      "filePath": "tokens/components/label/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.100.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-label-margin",
+      "attributes": {},
+      "path": [
+        "label",
+        "margin"
+      ]
+    },
+    "required": {
+      "margin": {
+        "value": "0 0 0 0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/label/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-label-required-margin",
+        "attributes": {},
+        "path": [
+          "label",
+          "required",
+          "margin"
+        ]
+      }
+    }
+  },
+  "lang-toggle": {
+    "active": {
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.active.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-active-text",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "active",
+          "text"
+        ]
+      },
+      "background": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.active.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-active-background",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "active",
+          "background"
+        ]
+      }
+    },
+    "default": {
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-default-text",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "background": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-focus-background",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "focus",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-focus-text",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "focus",
+          "text"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-lang-toggle-font-family",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-lang-toggle-font-size",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-lang-toggle-font-weight",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "hover": {
+      "text": {
+        "value": "#425A76",
+        "type": "color",
+        "filePath": "tokens/components/lang-toggle/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.700.value}",
+          "type": "color"
+        },
+        "name": "gcds-lang-toggle-hover-text",
+        "attributes": {},
+        "path": [
+          "lang-toggle",
+          "hover",
+          "text"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/lang-toggle/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-lang-toggle-line-height",
+      "attributes": {},
+      "path": [
+        "lang-toggle",
+        "lineHeight"
+      ]
+    },
+    "padding": {
+      "value": "1.125rem",
+      "type": "spacing",
+      "filePath": "tokens/components/lang-toggle/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.300.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-lang-toggle-padding",
+      "attributes": {},
+      "path": [
+        "lang-toggle",
+        "padding"
+      ]
+    }
+  },
+  "link": {
+    "dark": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/link/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-link-dark-text",
+        "attributes": {},
+        "path": [
+          "link",
+          "dark",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "text": {
+        "value": "#A62A1E",
+        "type": "color",
+        "filePath": "tokens/components/link/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.destructive.value}",
+          "type": "color"
+        },
+        "name": "gcds-link-destructive-text",
+        "attributes": {},
+        "path": [
+          "link",
+          "destructive",
+          "text"
+        ]
+      }
+    },
+    "light": {
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/link/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-link-light-text",
+        "attributes": {},
+        "path": [
+          "link",
+          "light",
+          "text"
+        ]
+      }
+    }
+  },
+  "pagination": {
+    "active": {
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-active-text",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "active",
+          "text"
+        ]
+      },
+      "background": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-active-background",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "active",
+          "background"
+        ]
+      }
+    },
+    "border": {
+      "color": {
+        "value": "#26374A",
+        "type": "border",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "border"
+        },
+        "name": "gcds-pagination-border-color",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "border",
+          "color"
+        ]
+      },
+      "radius": {
+        "value": "0.1875rem",
+        "type": "borderRadius",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "borderRadius"
+        },
+        "name": "gcds-pagination-border-radius",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "border",
+          "radius"
+        ]
+      },
+      "width": {
+        "value": ".125rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": ".125rem",
+          "type": "borderWidth"
+        },
+        "name": "gcds-pagination-border-width",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "default": {
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-default-text",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "hover": {
+      "background": {
+        "value": "#D7E5F5",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-hover-background",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "hover",
+          "background"
+        ]
+      }
+    },
+    "focus": {
+      "background": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-focus-background",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "focus",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-pagination-focus-text",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "focus",
+          "text"
+        ]
+      },
+      "shadow": {
+        "color": {
+          "value": "#FFF",
+          "type": "other",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "other"
+          },
+          "name": "gcds-pagination-focus-shadow-color",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "focus",
+            "shadow",
+            "color"
+          ]
+        }
+      },
+      "outline": {
+        "width": {
+          "value": "0.1875rem",
+          "type": "other",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "other"
+          },
+          "name": "gcds-pagination-focus-outline-width",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "focus",
+            "outline",
+            "width"
+          ]
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-pagination-font-family",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-pagination-font-size",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "700",
+        "type": "fontWeights",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.bold.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-pagination-font-weight",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/pagination/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-pagination-line-height",
+      "attributes": {},
+      "path": [
+        "pagination",
+        "lineHeight"
+      ]
+    },
+    "list": {
+      "endButton": {
+        "padding": {
+          "value": "0.75rem 0.5625rem",
+          "type": "spacing",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.200.value} {spacing.150.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-pagination-list-end-button-padding",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "list",
+            "endButton",
+            "padding"
+          ]
+        }
+      }
+    },
+    "listitem": {
+      "margin": {
+        "value": "0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-pagination-listitem-margin",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "listitem",
+          "margin"
+        ]
+      }
+    },
+    "mobile": {
+      "list": {
+        "border": {
+          "value": "#26374A",
+          "type": "border",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.blue.900.value}",
+            "type": "border"
+          },
+          "name": "gcds-pagination-mobile-list-border",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "mobile",
+            "list",
+            "border"
+          ]
+        },
+        "item": {
+          "margin": {
+            "value": ".125rem",
+            "type": "spacing",
+            "filePath": "tokens/components/pagination/base.json",
+            "isSource": true,
+            "original": {
+              "value": ".125rem",
+              "type": "spacing"
+            },
+            "name": "gcds-pagination-mobile-list-item-margin",
+            "attributes": {},
+            "path": [
+              "pagination",
+              "mobile",
+              "list",
+              "item",
+              "margin"
+            ]
+          }
+        },
+        "prevnext": {
+          "margin": {
+            "value": "0.75rem auto 0",
+            "type": "spacing",
+            "filePath": "tokens/components/pagination/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{spacing.200.value} auto 0",
+              "type": "spacing"
+            },
+            "name": "gcds-pagination-mobile-list-prevnext-margin",
+            "attributes": {},
+            "path": [
+              "pagination",
+              "mobile",
+              "list",
+              "prevnext",
+              "margin"
+            ]
+          }
+        }
+      }
+    },
+    "simple": {
+      "label": {
+        "fontWeight": {
+          "value": "400",
+          "type": "fontWeights",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontWeights.regular.value}",
+            "type": "fontWeights"
+          },
+          "name": "gcds-pagination-simple-label-font-weight",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "simple",
+            "label",
+            "fontWeight"
+          ]
+        }
+      },
+      "listitem": {
+        "margin": {
+          "value": "0.375rem 0.375rem 0.75rem",
+          "type": "spacing",
+          "filePath": "tokens/components/pagination/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.100.value} {spacing.100.value} {spacing.200.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-pagination-simple-listitem-margin",
+          "attributes": {},
+          "path": [
+            "pagination",
+            "simple",
+            "listitem",
+            "margin"
+          ]
+        }
+      },
+      "padding": {
+        "value": "0.75rem 0.5625rem",
+        "type": "spacing",
+        "filePath": "tokens/components/pagination/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value} {spacing.150.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-pagination-simple-padding",
+        "attributes": {},
+        "path": [
+          "pagination",
+          "simple",
+          "padding"
+        ]
+      }
+    }
+  },
+  "phaseBanner": {
+    "container": {
+      "xs": {
+        "value": "20rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xs.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-xs",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "xs"
+        ]
+      },
+      "sm": {
+        "value": "30rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.sm.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-sm",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "sm"
+        ]
+      },
+      "md": {
+        "value": "48rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.md.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-md",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "md"
+        ]
+      },
+      "lg": {
+        "value": "64rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.lg.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-lg",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "lg"
+        ]
+      },
+      "xl": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-xl",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "xl"
+        ]
+      },
+      "full": {
+        "value": "100%",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.full.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-container-full",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "container",
+          "full"
+        ]
+      }
+    },
+    "detailsCta": {
+      "margin": {
+        "value": "0 0 0 0.9375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.250.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-phase-banner-details-cta-margin",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "detailsCta",
+          "margin"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-phase-banner-font-family",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.1111111111111112rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.caption.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-phase-banner-font-size",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-phase-banner-font-weight",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "icon": {
+      "margin": {
+        "value": "1.125rem",
+        "type": "spacing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-phase-banner-icon-margin",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "icon",
+          "margin"
+        ]
+      },
+      "maxHeight": {
+        "value": "1.125rem",
+        "type": "sizing",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-phase-banner-icon-max-height",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "icon",
+          "maxHeight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "135%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/phase-banner/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.caption.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-phase-banner-line-height",
+      "attributes": {},
+      "path": [
+        "phaseBanner",
+        "lineHeight"
+      ]
+    },
+    "padding": {
+      "value": "0.9375rem",
+      "type": "spacing",
+      "filePath": "tokens/components/phase-banner/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.250.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-phase-banner-padding",
+      "attributes": {},
+      "path": [
+        "phaseBanner",
+        "padding"
+      ]
+    },
+    "primary": {
+      "background": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-phase-banner-primary-background",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "primary",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-phase-banner-primary-text",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "primary",
+          "text"
+        ]
+      }
+    },
+    "secondary": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.100.value}",
+          "type": "color"
+        },
+        "name": "gcds-phase-banner-secondary-background",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "secondary",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/phase-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-phase-banner-secondary-text",
+        "attributes": {},
+        "path": [
+          "phaseBanner",
+          "secondary",
+          "text"
+        ]
+      }
+    }
+  },
+  "radio": {
+    "border": {
+      "radius": {
+        "value": "3rem",
+        "type": "borderRadius",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "borderRadius"
+        },
+        "name": "gcds-radio-border-radius",
+        "attributes": {},
+        "path": [
+          "radio",
+          "border",
+          "radius"
+        ]
+      }
+    },
+    "check": {
+      "border": {
+        "width": {
+          "value": "0.3125rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/radio/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.3125rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-radio-check-border-width",
+          "attributes": {},
+          "path": [
+            "radio",
+            "check",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "heightAndWidth": {
+        "value": "1.125rem",
+        "type": "sizing",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-radio-check-height-and-width",
+        "attributes": {},
+        "path": [
+          "radio",
+          "check",
+          "heightAndWidth"
+        ]
+      },
+      "left": {
+        "value": "0.9375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.250.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-radio-check-left",
+        "attributes": {},
+        "path": [
+          "radio",
+          "check",
+          "left"
+        ]
+      },
+      "top": {
+        "value": "0.1875rem",
+        "type": "spacing",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-radio-check-top",
+        "attributes": {},
+        "path": [
+          "radio",
+          "check",
+          "top"
+        ]
+      }
+    },
+    "default": {
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-default-text",
+        "attributes": {},
+        "path": [
+          "radio",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "text": {
+        "value": "#A62A1E",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.destructive.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-destructive-text",
+        "attributes": {},
+        "path": [
+          "radio",
+          "destructive",
+          "text"
+        ]
+      }
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-disabled-background",
+        "attributes": {},
+        "path": [
+          "radio",
+          "disabled",
+          "background"
+        ]
+      },
+      "border": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-disabled-border",
+        "attributes": {},
+        "path": [
+          "radio",
+          "disabled",
+          "border"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-disabled-text",
+        "attributes": {},
+        "path": [
+          "radio",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-focus-text",
+        "attributes": {},
+        "path": [
+          "radio",
+          "focus",
+          "text"
+        ]
+      },
+      "outline": {
+        "width": {
+          "value": "0.1875rem",
+          "type": "other",
+          "filePath": "tokens/components/radio/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{spacing.50.value}",
+            "type": "other"
+          },
+          "name": "gcds-radio-focus-outline-width",
+          "attributes": {},
+          "path": [
+            "radio",
+            "focus",
+            "outline",
+            "width"
+          ]
+        }
+      },
+      "shadow": {
+        "color": {
+          "value": "#FFF",
+          "type": "other",
+          "filePath": "tokens/components/radio/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.0.value}",
+            "type": "other"
+          },
+          "name": "gcds-radio-focus-shadow-color",
+          "attributes": {},
+          "path": [
+            "radio",
+            "focus",
+            "shadow",
+            "color"
+          ]
+        }
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-radio-font-family",
+        "attributes": {},
+        "path": [
+          "radio",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-radio-font-size",
+        "attributes": {},
+        "path": [
+          "radio",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-radio-font-weight",
+        "attributes": {},
+        "path": [
+          "radio",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "input": {
+      "border": {
+        "width": {
+          "value": "0.125rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/radio/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.125rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-radio-input-border-width",
+          "attributes": {},
+          "path": [
+            "radio",
+            "input",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "heightAndWidth": {
+        "value": "3rem",
+        "type": "sizing",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-radio-input-height-and-width",
+        "attributes": {},
+        "path": [
+          "radio",
+          "input",
+          "heightAndWidth"
+        ]
+      }
+    },
+    "hint": {
+      "font": {
+        "size": {
+          "value": "1.1111111111111112rem",
+          "type": "fontSizes",
+          "filePath": "tokens/components/radio/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{fontSizes.caption.value}",
+            "type": "fontSizes"
+          },
+          "name": "gcds-radio-hint-font-size",
+          "attributes": {},
+          "path": [
+            "radio",
+            "hint",
+            "font",
+            "size"
+          ]
+        }
+      },
+      "lineHeight": {
+        "value": "135%",
+        "type": "lineHeights",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{lineHeights.caption.value}",
+          "type": "lineHeights"
+        },
+        "name": "gcds-radio-hint-line-height",
+        "attributes": {},
+        "path": [
+          "radio",
+          "hint",
+          "lineHeight"
+        ]
+      },
+      "text": {
+        "value": "#2F3238",
+        "type": "color",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-radio-hint-text",
+        "attributes": {},
+        "path": [
+          "radio",
+          "hint",
+          "text"
+        ]
+      }
+    },
+    "label": {
+      "padding": {
+        "value": "0 0 0 3.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/radio/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 0 {spacing.550.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-radio-label-padding",
+        "attributes": {},
+        "path": [
+          "radio",
+          "label",
+          "padding"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/radio/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-radio-line-height",
+      "attributes": {},
+      "path": [
+        "radio",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "2.25rem 0 1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/components/radio/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.450.value} 0 {spacing.400.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-radio-margin",
+      "attributes": {},
+      "path": [
+        "radio",
+        "margin"
+      ]
+    },
+    "top": {
+      "value": "-0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/radio/base.json",
+      "isSource": true,
+      "original": {
+        "value": "-{spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-radio-top",
+      "attributes": {},
+      "path": [
+        "radio",
+        "top"
+      ]
+    }
+  },
+  "select": {
+    "arrow": {
+      "positionX": {
+        "value": "calc(100% - 0.75rem)",
+        "type": "other",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "calc(100% - {spacing.200.value})",
+          "type": "other"
+        },
+        "name": "gcds-select-arrow-position-x",
+        "attributes": {},
+        "path": [
+          "select",
+          "arrow",
+          "positionX"
+        ]
+      }
+    },
+    "border": {
+      "radius": {
+        "value": "0.1875rem",
+        "type": "borderRadius",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "borderRadius"
+        },
+        "name": "gcds-select-border-radius",
+        "attributes": {},
+        "path": [
+          "select",
+          "border",
+          "radius"
+        ]
+      },
+      "width": {
+        "value": ".125rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": ".125rem",
+          "type": "borderWidth"
+        },
+        "name": "gcds-select-border-width",
+        "attributes": {},
+        "path": [
+          "select",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "default": {
+      "background": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-default-background",
+        "attributes": {},
+        "path": [
+          "select",
+          "default",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-default-text",
+        "attributes": {},
+        "path": [
+          "select",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "value": "#A62A1E",
+      "type": "color",
+      "filePath": "tokens/components/select/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{brand.destructive.value}",
+        "type": "color"
+      },
+      "name": "gcds-select-destructive",
+      "attributes": {},
+      "path": [
+        "select",
+        "destructive"
+      ]
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-disabled-background",
+        "attributes": {},
+        "path": [
+          "select",
+          "disabled",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-disabled-text",
+        "attributes": {},
+        "path": [
+          "select",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-focus-text",
+        "attributes": {},
+        "path": [
+          "select",
+          "focus",
+          "text"
+        ]
+      },
+      "shadow": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-select-focus-shadow",
+        "attributes": {},
+        "path": [
+          "select",
+          "focus",
+          "shadow"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-select-font-family",
+        "attributes": {},
+        "path": [
+          "select",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-select-font-size",
+        "attributes": {},
+        "path": [
+          "select",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-select-font-weight",
+        "attributes": {},
+        "path": [
+          "select",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/select/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-select-line-height",
+      "attributes": {},
+      "path": [
+        "select",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/components/select/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.400.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-select-margin",
+      "attributes": {},
+      "path": [
+        "select",
+        "margin"
+      ]
+    },
+    "minWidthAndHeight": {
+      "value": "3rem",
+      "type": "sizing",
+      "filePath": "tokens/components/select/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.500.value}",
+        "type": "sizing"
+      },
+      "name": "gcds-select-min-width-and-height",
+      "attributes": {},
+      "path": [
+        "select",
+        "minWidthAndHeight"
+      ]
+    },
+    "outline": {
+      "width": {
+        "value": "0.1875rem",
+        "type": "other",
+        "filePath": "tokens/components/select/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "other"
+        },
+        "name": "gcds-select-outline-width",
+        "attributes": {},
+        "path": [
+          "select",
+          "outline",
+          "width"
+        ]
+      }
+    },
+    "padding": {
+      "value": "0.75rem 3.75rem 0.75rem 0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/select/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.200.value} {spacing.550.value} {spacing.200.value} {spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-select-padding",
+      "attributes": {},
+      "path": [
+        "select",
+        "padding"
+      ]
+    }
+  },
+  "signature": {
+    "color": {
+      "flag": {
+        "value": "#FF0000",
+        "type": "color",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.red.flag.value}",
+          "type": "color"
+        },
+        "name": "gcds-signature-color-flag",
+        "attributes": {},
+        "path": [
+          "signature",
+          "color",
+          "flag"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-signature-color-text",
+        "attributes": {},
+        "path": [
+          "signature",
+          "color",
+          "text"
+        ]
+      }
+    },
+    "margin": {
+      "value": "0 0 0.375rem",
+      "type": "spacing",
+      "filePath": "tokens/components/signature/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.100.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-signature-margin",
+      "attributes": {},
+      "path": [
+        "signature",
+        "margin"
+      ]
+    },
+    "signature": {
+      "margin": {
+        "value": "0 0 0.375rem",
+        "type": "spacing",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "0 0 {spacing.100.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-signature-signature-margin",
+        "attributes": {},
+        "path": [
+          "signature",
+          "signature",
+          "margin"
+        ]
+      },
+      "height": {
+        "value": "1.6875rem",
+        "type": "sizing",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "1.6875rem",
+          "type": "sizing"
+        },
+        "name": "gcds-signature-signature-height",
+        "attributes": {},
+        "path": [
+          "signature",
+          "signature",
+          "height"
+        ]
+      }
+    },
+    "white": {
+      "default": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-signature-white-default",
+        "attributes": {},
+        "path": [
+          "signature",
+          "white",
+          "default"
+        ]
+      }
+    },
+    "wordmark": {
+      "margin": {
+        "value": "1.5rem 0",
+        "type": "spacing",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value} 0",
+          "type": "spacing"
+        },
+        "name": "gcds-signature-wordmark-margin",
+        "attributes": {},
+        "path": [
+          "signature",
+          "wordmark",
+          "margin"
+        ]
+      },
+      "height": {
+        "value": "3rem",
+        "type": "sizing",
+        "filePath": "tokens/components/signature/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.500.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-signature-wordmark-height",
+        "attributes": {},
+        "path": [
+          "signature",
+          "wordmark",
+          "height"
+        ]
+      }
+    }
+  },
+  "site-menu": {
+    "active": {
+      "background": {
+        "value": "#2F3238",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-active-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "active",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-active-text",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "active",
+          "text"
+        ]
+      }
+    },
+    "container": {
+      "maxWidth": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-site-menu-container-max-width",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "container",
+          "maxWidth"
+        ]
+      }
+    },
+    "default": {
+      "background": {
+        "value": "#F1F2F3",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.50.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-default-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "default",
+          "background"
+        ]
+      },
+      "border": {
+        "value": "#00030",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}30",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-default-border",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "default",
+          "border"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-default-text",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "background": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-focus-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "focus",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-focus-text",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "focus",
+          "text"
+        ]
+      }
+    },
+    "hover": {
+      "background": {
+        "value": "#A8ADB450",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.300.value}50",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-hover-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "hover",
+          "background"
+        ]
+      }
+    },
+    "selection": {
+      "background": {
+        "value": "#B3800F",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.yellow.500.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-selection-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "selection",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-selection-text",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "selection",
+          "text"
+        ]
+      }
+    },
+    "submenu": {
+      "background": {
+        "value": "#A8ADB4",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.300.value}",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-submenu-background",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "submenu",
+          "background"
+        ]
+      },
+      "box-shadow": {
+        "value": "#00030",
+        "type": "color",
+        "filePath": "tokens/components/site-menu/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}30",
+          "type": "color"
+        },
+        "name": "gcds-site-menu-submenu-box-shadow",
+        "attributes": {},
+        "path": [
+          "site-menu",
+          "submenu",
+          "box-shadow"
+        ]
+      },
+      "trigger": {
+        "text": {
+          "value": "#000",
+          "type": "color",
+          "filePath": "tokens/components/site-menu/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.1000.value}",
+            "type": "color"
+          },
+          "name": "gcds-site-menu-submenu-trigger-text",
+          "attributes": {},
+          "path": [
+            "site-menu",
+            "submenu",
+            "trigger",
+            "text"
+          ]
+        }
+      }
+    }
+  },
+  "stepper": {
+    "font": {
+      "family": {
+        "value": "Lato",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/stepper/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.heading.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-stepper-font-family",
+        "attributes": {},
+        "path": [
+          "stepper",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.40625rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/stepper/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.h6.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-stepper-font-size",
+        "attributes": {},
+        "path": [
+          "stepper",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "600",
+        "type": "fontWeights",
+        "filePath": "tokens/components/stepper/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.semibold.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-stepper-font-weight",
+        "attributes": {},
+        "path": [
+          "stepper",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "124.44444444444444%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/stepper/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.h6.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-stepper-line-height",
+      "attributes": {},
+      "path": [
+        "stepper",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 1.125rem",
+      "type": "spacing",
+      "filePath": "tokens/components/stepper/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.300.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-stepper-margin",
+      "attributes": {},
+      "path": [
+        "stepper",
+        "margin"
+      ]
+    },
+    "text": {
+      "value": "#545961",
+      "type": "color",
+      "filePath": "tokens/components/stepper/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.grayscale.700.value}",
+        "type": "color"
+      },
+      "name": "gcds-stepper-text",
+      "attributes": {},
+      "path": [
+        "stepper",
+        "text"
+      ]
+    }
+  },
+  "textarea": {
+    "border": {
+      "radius": {
+        "value": "0.1875rem",
+        "type": "borderRadius",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "borderRadius"
+        },
+        "name": "gcds-textarea-border-radius",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "border",
+          "radius"
+        ]
+      },
+      "width": {
+        "value": ".125rem",
+        "type": "borderWidth",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": ".125rem",
+          "type": "borderWidth"
+        },
+        "name": "gcds-textarea-border-width",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "border",
+          "width"
+        ]
+      }
+    },
+    "default": {
+      "background": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-default-background",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "default",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#000",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.1000.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-default-text",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "default",
+          "text"
+        ]
+      }
+    },
+    "destructive": {
+      "value": "#A62A1E",
+      "type": "color",
+      "filePath": "tokens/components/textarea/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{brand.destructive.value}",
+        "type": "color"
+      },
+      "name": "gcds-textarea-destructive",
+      "attributes": {},
+      "path": [
+        "textarea",
+        "destructive"
+      ]
+    },
+    "disabled": {
+      "background": {
+        "value": "#D6D9DD",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.background.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-disabled-background",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "disabled",
+          "background"
+        ]
+      },
+      "text": {
+        "value": "#545961",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.disabled.text.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-disabled-text",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "disabled",
+          "text"
+        ]
+      }
+    },
+    "focus": {
+      "text": {
+        "value": "#303FC3",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{brand.focus.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-focus-text",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "focus",
+          "text"
+        ]
+      },
+      "shadow": {
+        "value": "#FFF",
+        "type": "color",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.grayscale.0.value}",
+          "type": "color"
+        },
+        "name": "gcds-textarea-focus-shadow",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "focus",
+          "shadow"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-textarea-font-family",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.25rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.text.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-textarea-font-size",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-textarea-font-weight",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/textarea/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-textarea-line-height",
+      "attributes": {},
+      "path": [
+        "textarea",
+        "lineHeight"
+      ]
+    },
+    "margin": {
+      "value": "0 0 1.5rem",
+      "type": "spacing",
+      "filePath": "tokens/components/textarea/base.json",
+      "isSource": true,
+      "original": {
+        "value": "0 0 {spacing.400.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-textarea-margin",
+      "attributes": {},
+      "path": [
+        "textarea",
+        "margin"
+      ]
+    },
+    "minHeight": {
+      "value": "3rem",
+      "type": "sizing",
+      "filePath": "tokens/components/textarea/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.500.value}",
+        "type": "sizing"
+      },
+      "name": "gcds-textarea-min-height",
+      "attributes": {},
+      "path": [
+        "textarea",
+        "minHeight"
+      ]
+    },
+    "outline": {
+      "width": {
+        "value": "0.1875rem",
+        "type": "other",
+        "filePath": "tokens/components/textarea/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.50.value}",
+          "type": "other"
+        },
+        "name": "gcds-textarea-outline-width",
+        "attributes": {},
+        "path": [
+          "textarea",
+          "outline",
+          "width"
+        ]
+      }
+    },
+    "padding": {
+      "value": "0.75rem",
+      "type": "spacing",
+      "filePath": "tokens/components/textarea/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{spacing.200.value}",
+        "type": "spacing"
+      },
+      "name": "gcds-textarea-padding",
+      "attributes": {},
+      "path": [
+        "textarea",
+        "padding"
+      ]
+    }
+  },
+  "verify-banner": {
+    "background": {
+      "value": "#D6D9DD",
+      "type": "color",
+      "filePath": "tokens/components/verify-banner/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.grayscale.100.value}",
+        "type": "color"
+      },
+      "name": "gcds-verify-banner-background",
+      "attributes": {},
+      "path": [
+        "verify-banner",
+        "background"
+      ]
+    },
+    "container": {
+      "xs": {
+        "value": "20rem",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xs.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-xs",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "xs"
+        ]
+      },
+      "sm": {
+        "value": "30rem",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.sm.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-sm",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "sm"
+        ]
+      },
+      "md": {
+        "value": "48rem",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.md.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-md",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "md"
+        ]
+      },
+      "lg": {
+        "value": "64rem",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.lg.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-lg",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "lg"
+        ]
+      },
+      "xl": {
+        "value": "75rem",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.xl.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-xl",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "xl"
+        ]
+      },
+      "full": {
+        "value": "100%",
+        "type": "sizing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{container.full.value}",
+          "type": "sizing"
+        },
+        "name": "gcds-verify-banner-container-full",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "full"
+        ]
+      },
+      "padding": {
+        "value": "1.125rem",
+        "type": "spacing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.300.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-verify-banner-container-padding",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "container",
+          "padding"
+        ]
+      }
+    },
+    "content": {
+      "border": {
+        "color": {
+          "value": "#7D828B",
+          "type": "border",
+          "filePath": "tokens/components/verify-banner/base.json",
+          "isSource": true,
+          "original": {
+            "value": "{color.grayscale.500.value}",
+            "type": "border"
+          },
+          "name": "gcds-verify-banner-content-border-color",
+          "attributes": {},
+          "path": [
+            "verify-banner",
+            "content",
+            "border",
+            "color"
+          ]
+        },
+        "width": {
+          "value": "0.0625rem",
+          "type": "borderWidth",
+          "filePath": "tokens/components/verify-banner/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0.0625rem",
+            "type": "borderWidth"
+          },
+          "name": "gcds-verify-banner-content-border-width",
+          "attributes": {},
+          "path": [
+            "verify-banner",
+            "content",
+            "border",
+            "width"
+          ]
+        }
+      },
+      "heading": {
+        "margin": {
+          "value": "0 0 0.1875rem",
+          "type": "spacing",
+          "filePath": "tokens/components/verify-banner/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 {spacing.50.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-verify-banner-content-heading-margin",
+          "attributes": {},
+          "path": [
+            "verify-banner",
+            "content",
+            "heading",
+            "margin"
+          ]
+        }
+      },
+      "list": {
+        "margin": {
+          "value": "0 0 1.5rem",
+          "type": "spacing",
+          "filePath": "tokens/components/verify-banner/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 0 {spacing.400.value}",
+            "type": "spacing"
+          },
+          "name": "gcds-verify-banner-content-list-margin",
+          "attributes": {},
+          "path": [
+            "verify-banner",
+            "content",
+            "list",
+            "margin"
+          ]
+        },
+        "svg": {
+          "margin": {
+            "value": "0.1875rem",
+            "type": "spacing",
+            "filePath": "tokens/components/verify-banner/base.json",
+            "isSource": true,
+            "original": {
+              "value": "{spacing.50.value}",
+              "type": "spacing"
+            },
+            "name": "gcds-verify-banner-content-list-svg-margin",
+            "attributes": {},
+            "path": [
+              "verify-banner",
+              "content",
+              "list",
+              "svg",
+              "margin"
+            ]
+          }
+        }
+      },
+      "paddingBlockStart": {
+        "value": "1.5rem",
+        "type": "spacing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.400.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-verify-banner-content-padding-block-start",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "content",
+          "paddingBlockStart"
+        ]
+      },
+      "paddingBlockEnd": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-verify-banner-content-padding-block-end",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "content",
+          "paddingBlockEnd"
+        ]
+      }
+    },
+    "font": {
+      "family": {
+        "value": "Noto Sans",
+        "type": "fontFamilies",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontFamilies.body.value}",
+          "type": "fontFamilies"
+        },
+        "name": "gcds-verify-banner-font-family",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "font",
+          "family"
+        ]
+      },
+      "size": {
+        "value": "1.1111111111111112rem",
+        "type": "fontSizes",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontSizes.caption.value}",
+          "type": "fontSizes"
+        },
+        "name": "gcds-verify-banner-font-size",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "font",
+          "size"
+        ]
+      },
+      "weight": {
+        "value": "400",
+        "type": "fontWeights",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.regular.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-verify-banner-font-weight",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "font",
+          "weight"
+        ]
+      }
+    },
+    "lineHeight": {
+      "value": "120%",
+      "type": "lineHeights",
+      "filePath": "tokens/components/verify-banner/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{lineHeights.text.value}",
+        "type": "lineHeights"
+      },
+      "name": "gcds-verify-banner-line-height",
+      "attributes": {},
+      "path": [
+        "verify-banner",
+        "lineHeight"
+      ]
+    },
+    "summary": {
+      "padding": {
+        "value": "0.75rem",
+        "type": "spacing",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{spacing.200.value}",
+          "type": "spacing"
+        },
+        "name": "gcds-verify-banner-summary-padding",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "summary",
+          "padding"
+        ]
+      },
+      "content": {
+        "margin": {
+          "value": "0 1.125rem 0 0",
+          "type": "spacing",
+          "filePath": "tokens/components/verify-banner/base.json",
+          "isSource": true,
+          "original": {
+            "value": "0 {spacing.300.value} 0 0",
+            "type": "spacing"
+          },
+          "name": "gcds-verify-banner-summary-content-margin",
+          "attributes": {},
+          "path": [
+            "verify-banner",
+            "summary",
+            "content",
+            "margin"
+          ]
+        }
+      }
+    },
+    "text": {
+      "value": "#000",
+      "type": "color",
+      "filePath": "tokens/components/verify-banner/base.json",
+      "isSource": true,
+      "original": {
+        "value": "{color.grayscale.1000.value}",
+        "type": "color"
+      },
+      "name": "gcds-verify-banner-text",
+      "attributes": {},
+      "path": [
+        "verify-banner",
+        "text"
+      ]
+    },
+    "toggle": {
+      "text": {
+        "value": "#26374A",
+        "type": "color",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{color.blue.900.value}",
+          "type": "color"
+        },
+        "name": "gcds-verify-banner-toggle-text",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "toggle",
+          "text"
+        ]
+      },
+      "fontWeight": {
+        "value": "700",
+        "type": "fontWeights",
+        "filePath": "tokens/components/verify-banner/base.json",
+        "isSource": true,
+        "original": {
+          "value": "{fontWeights.bold.value}",
+          "type": "fontWeights"
+        },
+        "name": "gcds-verify-banner-toggle-font-weight",
+        "attributes": {},
+        "path": [
+          "verify-banner",
+          "toggle",
+          "fontWeight"
+        ]
+      }
+    }
+  }
+}

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 26 Jan 2023 19:18:49 GMT
+// Generated on Tue, 31 Jan 2023 14:42:02 GMT
 
 $gcds-brand-default-text: #000000;
 $gcds-brand-focus: #303fc3;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 26 Jan 2023 19:18:49 GMT
+ * Generated on Tue, 31 Jan 2023 14:42:02 GMT
  */
 
 :root {

--- a/config.js
+++ b/config.js
@@ -95,5 +95,17 @@ module.exports = {
         },
       ],
     },
+    docs: {
+      buildPath: 'build/',
+      prefix: 'gcds',
+      basePxFontSize: 20,
+      transforms: ['name/cti/kebab'],
+      files: [
+        {
+          destination: 'docs/tokens.json',
+          format: 'json',
+        },
+      ],
+    },
   },
 };


### PR DESCRIPTION
# Summary | Résumé

This is a suggestion for exporting a plain json data file of our tokens for the documentation site. It seems to contain some interesting items that could help us build the token names using the "name" key. Maybe its overkill, maybe we can be a bit more selective in our configuration. 