### PR TITLE
Update token push for gcds-docs

### DIFF
--- a/.github/workflows/compile-core.yml
+++ b/.github/workflows/compile-core.yml
@@ -40,13 +40,17 @@ jobs:
           destination-repository-name: 'gcds-components'
           user-email: ${{ secrets.USER_EMAIL }}
           target-branch: main
+      - name: Prep push to gcds-docs
+        run: |
+          cd build/figma
+          mv figma.token.json tokens.json
       - name: Push to gcds-docs
         uses: cpina/github-action-push-to-another-repository@9e487f29582587eeb4837c0552c886bb0644b6b9
         env:
           API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
         with:
-          source-directory: 'build/web/'
-          target-directory: 'src/variables/'
+          source-directory: 'build/figma/'
+          target-directory: 'src/_data/tokens/'
           destination-github-username: 'cds-snc'
           destination-repository-name: 'gcds-docs'
           user-email: ${{ secrets.USER_EMAIL }}

--- a/.github/workflows/compile-core.yml
+++ b/.github/workflows/compile-core.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Prep push to gcds-docs
         run: |
           cd build/figma
-          mv figma.token.json tokens.json
+          mv figma.token.json figma.json
       - name: Push to gcds-docs
         uses: cpina/github-action-push-to-another-repository@9e487f29582587eeb4837c0552c886bb0644b6b9
         env:


### PR DESCRIPTION
# Summary | Résumé

Update GitHub action to rename `figma.tokens.json` and push to `gcds-docs` repo to allow dynamic token tables.

Will merge after `v1-release` has been merged into `main`.
