### PR TITLE
Add new margin + padding tokens for gcds-breadcrumbs

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -856,6 +856,14 @@
           "value": "0 0 0 1.5rem",
           "type": "spacing"
         }
+      },
+      "margin": {
+        "value": "0 0 0 -0.375rem",
+        "type": "spacing"
+      },
+      "padding": {
+        "value": "0 0 0 0.375rem",
+        "type": "spacing"
       }
     },
     "button": {

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Fri, 21 Apr 2023 00:11:04 GMT
+// Generated on Tue, 25 Apr 2023 15:56:00 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -172,6 +172,8 @@ $gcds-breadcrumbs-item-first-child-margin: 0 0 0 -1.5rem;
 $gcds-breadcrumbs-item-link-padding: 0.1875rem;
 $gcds-breadcrumbs-item-margin: 0.75rem 0;
 $gcds-breadcrumbs-item-padding: 0 0 0 1.5rem;
+$gcds-breadcrumbs-margin: 0 0 0 -0.375rem;
+$gcds-breadcrumbs-padding: 0 0 0 0.375rem;
 $gcds-button-border-radius: 0.375rem;
 $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Fri, 21 Apr 2023 00:11:04 GMT
+ * Generated on Tue, 25 Apr 2023 15:56:00 GMT
  */
 
 :root {
@@ -174,6 +174,8 @@
   --gcds-breadcrumbs-item-link-padding: 0.1875rem;
   --gcds-breadcrumbs-item-margin: 0.75rem 0;
   --gcds-breadcrumbs-item-padding: 0 0 0 1.5rem;
+  --gcds-breadcrumbs-margin: 0 0 0 -0.375rem;
+  --gcds-breadcrumbs-padding: 0 0 0 0.375rem;
   --gcds-button-border-radius: 0.375rem;
   --gcds-button-border-width: 0.125rem;
   --gcds-button-danger-default-background: #a62a1e;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/breadcrumbs/base.json
+++ b/tokens/components/breadcrumbs/base.json
@@ -90,6 +90,14 @@
         "value": "0 0 0 {spacing.400.value}",
         "type": "spacing"
       }
+    },
+    "margin": {
+      "value": "0 0 0 -{spacing.100.value}",
+      "type": "spacing"
+    },
+    "padding": {
+      "value": "0 0 0 {spacing.100.value}",
+      "type": "spacing"
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Adding new padding and margin tokens to `gcds-breadcrumbs` to address https://github.com/cds-snc/gcds-components/issues/152.

Used in https://github.com/cds-snc/gcds-components/pull/153
