### PR TITLE
feat: publish new packages to CDN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,15 @@ on:
     paths:
       - 'package.json'
 
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CDN_BUCKET: gc-design-system-production-cdn
+  CDN_REGION: ca-central-1
+  PACKAGE_NAME: "@cdssnc/gcds-tokens"  
+
 jobs:
   build-deploy:
     name: Publish package
@@ -13,7 +22,33 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
       - name: Publish
         uses: JS-DevTools/npm-publish@c196e53609e852c243616a87994e8961a9903ba4
+        id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
+
+      - name: Configure AWS credentials using OIDC
+        if: steps.publish.outputs.id != ''
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::307395567143:role/gcds-components-apply
+          role-session-name: CDNPublish
+          aws-region: ${{ env.CDN_REGION }}
+
+      - name: Update CDN
+        if: steps.publish.outputs.id != ''
+        run: |
+          PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
+
+          mkdir -p ./tmp \
+            && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
+            && cd ./tmp/node_modules
+
+          aws s3 sync ./${{ env.PACKAGE_NAME }} s3://${{ env.CDN_BUCKET }}/"$PUBLISHED_PACKAGE" --delete
+          aws s3 sync ./${{ env.PACKAGE_NAME }} s3://${{ env.CDN_BUCKET }}/${{ env.PACKAGE_NAME }}@latest --delete
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key "$PUBLISHED_PACKAGE"/package.json
+          aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ env.PACKAGE_NAME }}@latest/package.json
+
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"                


### PR DESCRIPTION
# Summary
Update the publish package workflow so that new packages are now also published to the CDN.

Each new package will be published to a versioned directory in the CDN and replace the files for its @latest version. This will allow users to either link to versioned assets or the latest files.

# Related
- cds-snc/gcds-components#168
- cds-snc/platform-core-services#322