### PR TITLE
feat: Slack notify on publish workflow failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,3 +52,9 @@ jobs:
           aws s3api head-object --bucket ${{ env.CDN_BUCKET }} --key ${{ env.PACKAGE_NAME }}@latest/package.json
 
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"                
+
+      - name: Slack notify on failure
+        if: failure()
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Publish @cdssnc/gcds-tokens failed: <https://github.com/cds-snc/gcds-tokens/actions/workflows/publish.yml|Publish tokens>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_OPS }}


### PR DESCRIPTION
# Summary
Add a workflow step that posts a message to the Design System ops channel when the publish workflow fails.

# Related
- cds-snc/platform-core-services#333