### PR TITLE
Update alert token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -557,14 +557,6 @@
             "type": "borderWidth"
           }
         },
-        "active": {
-          "border": {
-            "color": {
-              "value": "#000",
-              "type": "color"
-            }
-          }
-        },
         "default": {
           "background": {
             "value": "#FFF",
@@ -2375,10 +2367,6 @@
         }
       },
       "border": {
-        "color": {
-          "value": "#2b4380",
-          "type": "border"
-        },
         "radius": {
           "value": "0.1875rem",
           "type": "borderRadius"

--- a/build/web/_variables.scss
+++ b/build/web/_variables.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 31 May 2023 18:44:56 GMT
+// Generated on Thu, 01 Jun 2023 23:04:57 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -116,7 +116,6 @@ $gcds-font-text-long: 400 1.25rem/150% "Noto Sans", sans-serif;
 $gcds-alert-border-width: 0.375rem;
 $gcds-alert-button-border-radius: 0.375rem;
 $gcds-alert-button-border-width: 0.125rem;
-$gcds-alert-button-active-border-color: #000000;
 $gcds-alert-button-default-background: #ffffff;
 $gcds-alert-button-default-text: #333333;
 $gcds-alert-button-focus-background: #0535d2;
@@ -456,7 +455,6 @@ $gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
 $gcds-lang-toggle-padding: 0.5625rem;
 $gcds-pagination-active-text: #ffffff;
 $gcds-pagination-active-background: #26374a;
-$gcds-pagination-border-color: #2b4380;
 $gcds-pagination-border-radius: 0.1875rem;
 $gcds-pagination-border-width: 0.125rem;
 $gcds-pagination-default-text: #2b4380;

--- a/build/web/variables.css
+++ b/build/web/variables.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 31 May 2023 18:44:56 GMT
+ * Generated on Thu, 01 Jun 2023 23:04:57 GMT
  */
 
 :root {
@@ -118,7 +118,6 @@
   --gcds-alert-border-width: 0.375rem;
   --gcds-alert-button-border-radius: 0.375rem;
   --gcds-alert-button-border-width: 0.125rem;
-  --gcds-alert-button-active-border-color: #000000;
   --gcds-alert-button-default-background: #ffffff;
   --gcds-alert-button-default-text: #333333;
   --gcds-alert-button-focus-background: #0535d2;
@@ -458,7 +457,6 @@
   --gcds-lang-toggle-padding: 0.5625rem;
   --gcds-pagination-active-text: #ffffff;
   --gcds-pagination-active-background: #26374a;
-  --gcds-pagination-border-color: #2b4380;
   --gcds-pagination-border-radius: 0.1875rem;
   --gcds-pagination-border-width: 0.125rem;
   --gcds-pagination-default-text: #2b4380;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/alert/base.json
+++ b/tokens/components/alert/base.json
@@ -17,14 +17,6 @@
           "type": "borderWidth"
         }
       },
-      "active": {
-        "border": {
-          "color": {
-            "value": "{color.grayscale.1000.value}",
-            "type": "color"
-          }
-        }
-      },
       "default": {
         "background": {
           "value": "{color.grayscale.0.value}",

--- a/tokens/components/pagination/base.json
+++ b/tokens/components/pagination/base.json
@@ -11,10 +11,6 @@
       }
     },
     "border": {
-      "color": {
-        "value": "{link.default.value}",
-        "type": "border"
-      },
       "radius": {
         "value": "{border.radius.sm.value}",
         "type": "borderRadius"


### PR DESCRIPTION
# V 1.1.3

## Patch

- [8c2aff2](https://github.com/cds-snc/gcds-tokens/commit/8c2aff2c03db5d3f7aa08ae0271f71a3d7a8fc74) - Remove alert active border + pagination border tokens

Notes:

Removing these two tokens as they can be replaced with `currentColor` in the components CSS.