### PR TITLE
Gcds search border-radius fix

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3099,7 +3099,7 @@
     "search": {
       "border": {
         "radius": {
-          "value": "0.1875rem",
+          "value": "0.1875rem 0 0 0.1875rem",
           "type": "borderRadius"
         },
         "width": {
@@ -3118,6 +3118,12 @@
         }
       },
       "focus": {
+        "border": {
+          "radius": {
+            "value": "0.1875rem",
+            "type": "borderRadius"
+          }
+        },
         "boxShadow": {
           "value": "0 0 0 0.125rem #FFF",
           "type": "other"

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 03 Aug 2023 12:54:10 GMT
+ * Generated on Thu, 03 Aug 2023 19:14:40 GMT
  */
 
 :root {
@@ -591,10 +591,11 @@
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 2.25rem 0 1.5rem;
   --gcds-radio-top: -0.75rem;
-  --gcds-search-border-radius: 0.1875rem;
+  --gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
   --gcds-search-border-width: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
+  --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
   --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 03 Aug 2023 12:54:09 GMT
+ * Generated on Thu, 03 Aug 2023 19:14:39 GMT
  */
 
 :root {
@@ -480,10 +480,11 @@
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 2.25rem 0 1.5rem;
   --gcds-radio-top: -0.75rem;
-  --gcds-search-border-radius: 0.1875rem;
+  --gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
   --gcds-search-border-width: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
+  --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
   --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/components/search.css
+++ b/build/web/css/components/search.css
@@ -1,13 +1,14 @@
 /**
  * Do not edit directly
- * Generated on Tue, 01 Aug 2023 18:14:52 GMT
+ * Generated on Thu, 03 Aug 2023 19:14:40 GMT
  */
 
 :root {
-  --gcds-search-border-radius: 0.1875rem;
+  --gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
   --gcds-search-border-width: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
+  --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
   --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 03 Aug 2023 12:54:09 GMT
+ * Generated on Thu, 03 Aug 2023 19:14:39 GMT
  */
 
 :root {
@@ -591,10 +591,11 @@
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 2.25rem 0 1.5rem;
   --gcds-radio-top: -0.75rem;
-  --gcds-search-border-radius: 0.1875rem;
+  --gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
   --gcds-search-border-width: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
+  --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
   --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:54:09 GMT
+// Generated on Thu, 03 Aug 2023 19:14:39 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -589,10 +589,11 @@ $gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 2.25rem 0 1.5rem;
 $gcds-radio-top: -0.75rem;
-$gcds-search-border-radius: 0.1875rem;
+$gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
 $gcds-search-border-width: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
+$gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
 $gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:54:09 GMT
+// Generated on Thu, 03 Aug 2023 19:14:39 GMT
 
 $gcds-container-border: 0.0625rem solid #7d828b;
 $gcds-container-size-xs: 20rem;
@@ -478,10 +478,11 @@ $gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 2.25rem 0 1.5rem;
 $gcds-radio-top: -0.75rem;
-$gcds-search-border-radius: 0.1875rem;
+$gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
 $gcds-search-border-width: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
+$gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
 $gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/components/search.scss
+++ b/build/web/scss/components/search.scss
@@ -1,11 +1,12 @@
 
 // Do not edit directly
-// Generated on Tue, 01 Aug 2023 18:14:51 GMT
+// Generated on Thu, 03 Aug 2023 19:14:39 GMT
 
-$gcds-search-border-radius: 0.1875rem;
+$gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
 $gcds-search-border-width: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
+$gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
 $gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:54:09 GMT
+// Generated on Thu, 03 Aug 2023 19:14:39 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -589,10 +589,11 @@ $gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 2.25rem 0 1.5rem;
 $gcds-radio-top: -0.75rem;
-$gcds-search-border-radius: 0.1875rem;
+$gcds-search-border-radius: 0.1875rem 0 0 0.1875rem;
 $gcds-search-border-width: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
+$gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
 $gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -2,7 +2,7 @@
   "search": {
     "border": {
       "radius": {
-        "value": "{border.radius.sm.value}",
+        "value": "{border.radius.sm.value} 0 0 {border.radius.sm.value}",
         "type": "borderRadius"
       },
       "width": {
@@ -21,6 +21,12 @@
       }
     },
     "focus": {
+      "border": {
+        "radius": {
+          "value": "{border.radius.sm.value}",
+          "type": "borderRadius"
+        }
+      },
       "boxShadow": {
         "value": "0 0 0 {border.width.md.value} {focus.text.value}",
         "type": "other"


### PR DESCRIPTION
# Summary | Résumé

Change `border-radius` token in `gcds-search` to use `border-radius: value value value value` format. The bottom right of the search component was not properly reading the border radius values. 
