### PR TITLE
V 1.5.5

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2048,12 +2048,12 @@
               "type": "sizing"
             },
             "margin": {
-              "value": "0 0 0 auto",
+              "value": "2.25rem 0 2.25rem auto",
               "type": "spacing"
             }
           },
           "margin": {
-            "value": "0 0 1.5rem auto",
+            "value": "2.25rem 0 3.75rem auto",
             "type": "spacing"
           }
         },
@@ -2196,6 +2196,12 @@
         "padding": {
           "value": "0 0 0.375rem",
           "type": "spacing"
+        },
+        "signature": {
+          "margin": {
+            "value": "0 0 0.375rem",
+            "type": "spacing"
+          }
         },
         "toggle": {
           "padding": {
@@ -3382,15 +3388,7 @@
           "type": "color"
         }
       },
-      "margin": {
-        "value": "0 0 0.375rem",
-        "type": "spacing"
-      },
       "signature": {
-        "margin": {
-          "value": "0 0 0.375rem",
-          "type": "spacing"
-        },
         "height": {
           "value": "1.6875rem",
           "type": "sizing"
@@ -3403,10 +3401,6 @@
         }
       },
       "wordmark": {
-        "margin": {
-          "value": "2.25rem 0",
-          "type": "spacing"
-        },
         "height": {
           "value": "3rem",
           "type": "sizing"

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2220,7 +2220,7 @@
         "value": "0 0 0.75rem",
         "type": "spacing"
       },
-      "topnav": {
+      "skiptonav": {
         "top": {
           "value": "1.5rem",
           "type": "spacing"

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2901,7 +2901,7 @@
           "font": {
             "value": {
               "fontFamily": "\"Noto Sans\", sans-serif",
-              "fontWeight": "500",
+              "fontWeight": "600",
               "lineHeight": "126.41975308641975%",
               "fontSize": "1.58203125rem"
             },

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 00:58:38 GMT
+ * Generated on Wed, 23 Aug 2023 01:07:09 GMT
  */
 
 :root {
@@ -559,7 +559,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 01:07:09 GMT
+ * Generated on Wed, 23 Aug 2023 01:41:47 GMT
  */
 
 :root {
@@ -427,7 +427,7 @@
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
-  --gcds-header-topnav-top: 1.5rem;
+  --gcds-header-skiptonav-top: 1.5rem;
   --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 0.75rem;
   --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Aug 2023 12:29:55 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
@@ -391,8 +391,8 @@
   --gcds-footer-sub-nav-padding: 3rem 0;
   --gcds-footer-sub-signature-lg-width: 10.937rem;
   --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-  --gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
   --gcds-footer-sub-md-width: 7rem;
   --gcds-footer-sub-sm-width: 100%;
   --gcds-footer-sub-text: #2b4380;
@@ -423,6 +423,7 @@
   --gcds-header-brand-grid-gap: 0.75rem;
   --gcds-header-brand-margin: 1.125rem 0 0;
   --gcds-header-brand-padding: 0 0 0.375rem;
+  --gcds-header-brand-signature-margin: 0 0 0.375rem;
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
@@ -643,11 +644,8 @@
   --gcds-side-nav-max-width: 20rem;
   --gcds-signature-color-flag: #ff0000;
   --gcds-signature-color-text: #000000;
-  --gcds-signature-margin: 0 0 0.375rem;
-  --gcds-signature-signature-margin: 0 0 0.375rem;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
-  --gcds-signature-wordmark-margin: 2.25rem 0;
   --gcds-signature-wordmark-height: 3rem;
   --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Aug 2023 12:29:55 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
@@ -280,8 +280,8 @@
   --gcds-footer-sub-nav-padding: 3rem 0;
   --gcds-footer-sub-signature-lg-width: 10.937rem;
   --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-  --gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
   --gcds-footer-sub-md-width: 7rem;
   --gcds-footer-sub-sm-width: 100%;
   --gcds-footer-sub-text: #2b4380;
@@ -312,6 +312,7 @@
   --gcds-header-brand-grid-gap: 0.75rem;
   --gcds-header-brand-margin: 1.125rem 0 0;
   --gcds-header-brand-padding: 0 0 0.375rem;
+  --gcds-header-brand-signature-margin: 0 0 0.375rem;
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
@@ -532,11 +533,8 @@
   --gcds-side-nav-max-width: 20rem;
   --gcds-signature-color-flag: #ff0000;
   --gcds-signature-color-text: #000000;
-  --gcds-signature-margin: 0 0 0.375rem;
-  --gcds-signature-signature-margin: 0 0 0.375rem;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
-  --gcds-signature-wordmark-margin: 2.25rem 0;
   --gcds-signature-wordmark-height: 3rem;
   --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 01:07:09 GMT
+ * Generated on Wed, 23 Aug 2023 01:41:47 GMT
  */
 
 :root {
@@ -316,7 +316,7 @@
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
-  --gcds-header-topnav-top: 1.5rem;
+  --gcds-header-skiptonav-top: 1.5rem;
   --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 0.75rem;
   --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 00:58:38 GMT
+ * Generated on Wed, 23 Aug 2023 01:07:09 GMT
  */
 
 :root {
@@ -448,7 +448,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;

--- a/build/web/css/components/footer.css
+++ b/build/web/css/components/footer.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 27 Jun 2023 23:49:41 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
@@ -28,8 +28,8 @@
   --gcds-footer-sub-nav-padding: 3rem 0;
   --gcds-footer-sub-signature-lg-width: 10.937rem;
   --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-  --gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
   --gcds-footer-sub-md-width: 7rem;
   --gcds-footer-sub-sm-width: 100%;
   --gcds-footer-sub-text: #2b4380;

--- a/build/web/css/components/header.css
+++ b/build/web/css/components/header.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 03 Aug 2023 12:54:09 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
@@ -9,6 +9,7 @@
   --gcds-header-brand-grid-gap: 0.75rem;
   --gcds-header-brand-margin: 1.125rem 0 0;
   --gcds-header-brand-padding: 0 0 0.375rem;
+  --gcds-header-brand-signature-margin: 0 0 0.375rem;
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;

--- a/build/web/css/components/header.css
+++ b/build/web/css/components/header.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 00:58:38 GMT
+ * Generated on Wed, 23 Aug 2023 01:41:47 GMT
  */
 
 :root {
@@ -13,5 +13,5 @@
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
-  --gcds-header-topnav-top: 1.5rem;
+  --gcds-header-skiptonav-top: 1.5rem;
 }

--- a/build/web/css/components/nav-link.css
+++ b/build/web/css/components/nav-link.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 10 Aug 2023 15:16:26 GMT
+ * Generated on Wed, 23 Aug 2023 01:07:09 GMT
  */
 
 :root {
@@ -27,7 +27,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;

--- a/build/web/css/components/signature.css
+++ b/build/web/css/components/signature.css
@@ -1,15 +1,12 @@
 /**
  * Do not edit directly
- * Generated on Mon, 19 Jun 2023 20:28:18 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
   --gcds-signature-color-flag: #ff0000;
   --gcds-signature-color-text: #000000;
-  --gcds-signature-margin: 0 0 0.375rem;
-  --gcds-signature-signature-margin: 0 0 0.375rem;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
-  --gcds-signature-wordmark-margin: 2.25rem 0;
   --gcds-signature-wordmark-height: 3rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 00:58:38 GMT
+ * Generated on Wed, 23 Aug 2023 01:07:09 GMT
  */
 
 :root {
@@ -559,7 +559,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 23 Aug 2023 01:07:09 GMT
+ * Generated on Wed, 23 Aug 2023 01:41:47 GMT
  */
 
 :root {
@@ -427,7 +427,7 @@
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
-  --gcds-header-topnav-top: 1.5rem;
+  --gcds-header-skiptonav-top: 1.5rem;
   --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 0.75rem;
   --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Aug 2023 12:29:55 GMT
+ * Generated on Wed, 23 Aug 2023 00:58:38 GMT
  */
 
 :root {
@@ -391,8 +391,8 @@
   --gcds-footer-sub-nav-padding: 3rem 0;
   --gcds-footer-sub-signature-lg-width: 10.937rem;
   --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-  --gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
   --gcds-footer-sub-md-width: 7rem;
   --gcds-footer-sub-sm-width: 100%;
   --gcds-footer-sub-text: #2b4380;
@@ -423,6 +423,7 @@
   --gcds-header-brand-grid-gap: 0.75rem;
   --gcds-header-brand-margin: 1.125rem 0 0;
   --gcds-header-brand-padding: 0 0 0.375rem;
+  --gcds-header-brand-signature-margin: 0 0 0.375rem;
   --gcds-header-brand-toggle-padding: 0 1.125rem;
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
@@ -643,11 +644,8 @@
   --gcds-side-nav-max-width: 20rem;
   --gcds-signature-color-flag: #ff0000;
   --gcds-signature-color-text: #000000;
-  --gcds-signature-margin: 0 0 0.375rem;
-  --gcds-signature-signature-margin: 0 0 0.375rem;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
-  --gcds-signature-wordmark-margin: 2.25rem 0;
   --gcds-signature-wordmark-height: 3rem;
   --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 16 Aug 2023 12:29:55 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -389,8 +389,8 @@ $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
 $gcds-footer-sub-nav-padding: 3rem 0;
 $gcds-footer-sub-signature-lg-width: 10.937rem;
 $gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-$gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
 $gcds-footer-sub-md-width: 7rem;
 $gcds-footer-sub-sm-width: 100%;
 $gcds-footer-sub-text: #2b4380;
@@ -421,6 +421,7 @@ $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;
 $gcds-header-brand-margin: 1.125rem 0 0;
 $gcds-header-brand-padding: 0 0 0.375rem;
+$gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
@@ -641,11 +642,8 @@ $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
 $gcds-signature-color-flag: #ff0000;
 $gcds-signature-color-text: #000000;
-$gcds-signature-margin: 0 0 0.375rem;
-$gcds-signature-signature-margin: 0 0 0.375rem;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
-$gcds-signature-wordmark-margin: 2.25rem 0;
 $gcds-signature-wordmark-height: 3rem;
 $gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 00:58:38 GMT
+// Generated on Wed, 23 Aug 2023 01:07:09 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -557,7 +557,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 01:07:09 GMT
+// Generated on Wed, 23 Aug 2023 01:41:47 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -425,7 +425,7 @@ $gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
-$gcds-header-topnav-top: 1.5rem;
+$gcds-header-skiptonav-top: 1.5rem;
 $gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 0.75rem;
 $gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 01:07:08 GMT
+// Generated on Wed, 23 Aug 2023 01:41:47 GMT
 
 $gcds-container-border: 0.0625rem solid #7d828b;
 $gcds-container-size-xs: 20rem;
@@ -314,7 +314,7 @@ $gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
-$gcds-header-topnav-top: 1.5rem;
+$gcds-header-skiptonav-top: 1.5rem;
 $gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 0.75rem;
 $gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 00:58:38 GMT
+// Generated on Wed, 23 Aug 2023 01:07:08 GMT
 
 $gcds-container-border: 0.0625rem solid #7d828b;
 $gcds-container-size-xs: 20rem;
@@ -446,7 +446,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 16 Aug 2023 12:29:54 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-container-border: 0.0625rem solid #7d828b;
 $gcds-container-size-xs: 20rem;
@@ -278,8 +278,8 @@ $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
 $gcds-footer-sub-nav-padding: 3rem 0;
 $gcds-footer-sub-signature-lg-width: 10.937rem;
 $gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-$gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
 $gcds-footer-sub-md-width: 7rem;
 $gcds-footer-sub-sm-width: 100%;
 $gcds-footer-sub-text: #2b4380;
@@ -310,6 +310,7 @@ $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;
 $gcds-header-brand-margin: 1.125rem 0 0;
 $gcds-header-brand-padding: 0 0 0.375rem;
+$gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
@@ -530,11 +531,8 @@ $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
 $gcds-signature-color-flag: #ff0000;
 $gcds-signature-color-text: #000000;
-$gcds-signature-margin: 0 0 0.375rem;
-$gcds-signature-signature-margin: 0 0 0.375rem;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
-$gcds-signature-wordmark-margin: 2.25rem 0;
 $gcds-signature-wordmark-height: 3rem;
 $gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;

--- a/build/web/scss/components/footer.scss
+++ b/build/web/scss/components/footer.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 27 Jun 2023 23:49:40 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-footer-container-margin: 0 auto;
 $gcds-footer-container-width: 71.25rem;
@@ -26,8 +26,8 @@ $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
 $gcds-footer-sub-nav-padding: 3rem 0;
 $gcds-footer-sub-signature-lg-width: 10.937rem;
 $gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-$gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
 $gcds-footer-sub-md-width: 7rem;
 $gcds-footer-sub-sm-width: 100%;
 $gcds-footer-sub-text: #2b4380;

--- a/build/web/scss/components/header.scss
+++ b/build/web/scss/components/header.scss
@@ -1,12 +1,13 @@
 
 // Do not edit directly
-// Generated on Thu, 03 Aug 2023 12:54:09 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-header-brand-border-color: #26374a;
 $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;
 $gcds-header-brand-margin: 1.125rem 0 0;
 $gcds-header-brand-padding: 0 0 0.375rem;
+$gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;

--- a/build/web/scss/components/header.scss
+++ b/build/web/scss/components/header.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 00:58:38 GMT
+// Generated on Wed, 23 Aug 2023 01:41:47 GMT
 
 $gcds-header-brand-border-color: #26374a;
 $gcds-header-brand-border-width: 0.1875rem;
@@ -11,4 +11,4 @@ $gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
-$gcds-header-topnav-top: 1.5rem;
+$gcds-header-skiptonav-top: 1.5rem;

--- a/build/web/scss/components/nav-link.scss
+++ b/build/web/scss/components/nav-link.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 10 Aug 2023 15:16:25 GMT
+// Generated on Wed, 23 Aug 2023 01:07:09 GMT
 
 $gcds-nav-link-active-border-color: #33465c;
 $gcds-nav-link-active-font-weight: 700;
@@ -25,7 +25,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;

--- a/build/web/scss/components/signature.scss
+++ b/build/web/scss/components/signature.scss
@@ -1,12 +1,9 @@
 
 // Do not edit directly
-// Generated on Mon, 19 Jun 2023 20:28:18 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-signature-color-flag: #ff0000;
 $gcds-signature-color-text: #000000;
-$gcds-signature-margin: 0 0 0.375rem;
-$gcds-signature-signature-margin: 0 0 0.375rem;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
-$gcds-signature-wordmark-margin: 2.25rem 0;
 $gcds-signature-wordmark-height: 3rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 01:07:08 GMT
+// Generated on Wed, 23 Aug 2023 01:41:47 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -425,7 +425,7 @@ $gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
-$gcds-header-topnav-top: 1.5rem;
+$gcds-header-skiptonav-top: 1.5rem;
 $gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 0.75rem;
 $gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 23 Aug 2023 00:58:38 GMT
+// Generated on Wed, 23 Aug 2023 01:07:08 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -557,7 +557,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font: 500 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 16 Aug 2023 12:29:54 GMT
+// Generated on Wed, 23 Aug 2023 00:58:38 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -389,8 +389,8 @@ $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
 $gcds-footer-sub-nav-padding: 3rem 0;
 $gcds-footer-sub-signature-lg-width: 10.937rem;
 $gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 0 0 0 auto;
-$gcds-footer-sub-signature-margin: 0 0 1.5rem auto;
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
+$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
 $gcds-footer-sub-md-width: 7rem;
 $gcds-footer-sub-sm-width: 100%;
 $gcds-footer-sub-text: #2b4380;
@@ -421,6 +421,7 @@ $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;
 $gcds-header-brand-margin: 1.125rem 0 0;
 $gcds-header-brand-padding: 0 0 0.375rem;
+$gcds-header-brand-signature-margin: 0 0 0.375rem;
 $gcds-header-brand-toggle-padding: 0 1.125rem;
 $gcds-header-container-max-width: 71.25rem;
 $gcds-header-margin: 0 0 0.75rem;
@@ -641,11 +642,8 @@ $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
 $gcds-signature-color-flag: #ff0000;
 $gcds-signature-color-text: #000000;
-$gcds-signature-margin: 0 0 0.375rem;
-$gcds-signature-signature-margin: 0 0 0.375rem;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
-$gcds-signature-wordmark-margin: 2.25rem 0;
 $gcds-signature-wordmark-height: 3rem;
 $gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/footer/tokens.json
+++ b/tokens/components/footer/tokens.json
@@ -137,12 +137,12 @@
             "type": "sizing"
           },
           "margin": {
-            "value": "0 0 0 auto",
+            "value": "{spacing.450.value} 0 {spacing.450.value} auto",
             "type": "spacing"
           }
         },
         "margin": {
-          "value": "0 0 {spacing.400.value} auto",
+          "value": "{spacing.450.value} 0 {spacing.550.value} auto",
           "type": "spacing"
         }
       },

--- a/tokens/components/header/tokens.json
+++ b/tokens/components/header/tokens.json
@@ -48,7 +48,7 @@
       "value": "0 0 {spacing.200.value}",
       "type": "spacing"
     },
-    "topnav": {
+    "skiptonav": {
       "top": {
         "value": "{spacing.400.value}",
         "type": "spacing"

--- a/tokens/components/header/tokens.json
+++ b/tokens/components/header/tokens.json
@@ -25,6 +25,12 @@
         "value": "0 0 {spacing.100.value}",
         "type": "spacing"
       },
+      "signature": {
+        "margin": {
+          "value": "0 0 {spacing.100.value}",
+          "type": "spacing"
+        }
+      },
       "toggle": {
         "padding": {
           "value": "0 {spacing.300.value}",

--- a/tokens/components/nav-link/tokens.json
+++ b/tokens/components/nav-link/tokens.json
@@ -126,7 +126,7 @@
         "font": {
           "value": {
             "fontFamily": "{fontFamilies.body}",
-            "fontWeight": "{fontWeights.medium}",
+            "fontWeight": "{fontWeights.semibold}",
             "lineHeight": "{lineHeights.h5}",
             "fontSize": "{fontSizes.h5}"
           },

--- a/tokens/components/signature/tokens.json
+++ b/tokens/components/signature/tokens.json
@@ -10,15 +10,7 @@
         "type": "color"
       }
     },
-    "margin": {
-      "value": "0 0 {spacing.100.value}",
-      "type": "spacing"
-    },
     "signature": {
-      "margin": {
-        "value": "0 0 {spacing.100.value}",
-        "type": "spacing"
-      },
       "height": {
         "value": "1.6875rem",
         "type": "sizing"
@@ -31,10 +23,6 @@
       }
     },
     "wordmark": {
-      "margin": {
-        "value": "{spacing.450.value} 0",
-        "type": "spacing"
-      },
       "height": {
         "value": "{spacing.500.value}",
         "type": "sizing"


### PR DESCRIPTION
# V 1.5.5

## Patch

- Add footer + header margins for signature in footer + header css, remove from signature css to avoid incorrect margins in other places
- Change top nav home link font-weight from `medium` to `semibold` to match Figma component

## Breaking change
- Rename header `topnav` slot to `skip-to-nav` to avoid confusion with new top-nav component.