### PR TITLE
feat: send deployment metrics to sentinel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,15 @@ jobs:
 
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CLOUDFRONT_DIST_ID }} --paths "/*"
 
+      - name: Report deployment to Sentinel
+        if: steps.publish.outputs.id != ''
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+          input_data: '{"product": "design-system", "sha": "${{ github.sha }}", "version": "${{steps.publish.outputs.id}}", "repository": "${{ github.repository }}", "environment": "production", "status": "${{ job.status }}"}'
+          log_type: CDS_Product_Deployment_Data
+          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
       - name: Slack notify on failure
         if: failure()
         run: |


### PR DESCRIPTION
### What does this MR do?

This will be used to help calculate the deployment frequency for this
repo.

Currently it will only run if a package is published in the NPM Publish
step.


### Related issues

https://github.com/cds-snc/platform-core-services/issues/350
