### PR TITLE
Add focus box-shadow to multiple components

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1393,6 +1393,10 @@
             "value": "#0535d2",
             "type": "color"
           },
+          "box-shadow": {
+            "value": "0 0 0 0.125rem #FFF",
+            "type": "color"
+          },
           "outline": {
             "width": {
               "value": "0.1875rem",
@@ -1630,6 +1634,14 @@
         }
       },
       "focus": {
+        "background": {
+          "value": "#FFF",
+          "type": "color"
+        },
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#0535d2",
           "type": "color"
@@ -3013,6 +3025,10 @@
         }
       },
       "focus": {
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#0535d2",
           "type": "color"
@@ -3525,6 +3541,10 @@
           "value": "#0535d2",
           "type": "color"
         },
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#FFF",
           "type": "color"
@@ -3709,6 +3729,14 @@
         }
       },
       "focus": {
+        "background": {
+          "value": "#FFF",
+          "type": "color"
+        },
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#0535d2",
           "type": "color"
@@ -3876,6 +3904,10 @@
         }
       },
       "focus": {
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#0535d2",
           "type": "color"
@@ -4021,6 +4053,10 @@
         }
       },
       "focus": {
+        "box-shadow": {
+          "value": "0 0 0 0.125rem #FFF",
+          "type": "color"
+        },
         "text": {
           "value": "#0535d2",
           "type": "color"

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 18:11:33 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -273,6 +273,7 @@
   --gcds-button-shared-active-background: #000000;
   --gcds-button-shared-active-text: #ffffff;
   --gcds-button-shared-focus-background: #0535d2;
+  --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.1875rem;
   --gcds-button-shared-focus-text: #ffffff;
   --gcds-button-shared-disabled-background: #d6d9dd;
@@ -317,6 +318,8 @@
   --gcds-checkbox-disabled-border: #545961;
   --gcds-checkbox-disabled-text: #545961;
   --gcds-checkbox-error-padding: 0 0 0 3.75rem;
+  --gcds-checkbox-focus-background: #ffffff;
+  --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
   --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -573,6 +576,7 @@
   --gcds-input-default-text: #333333;
   --gcds-input-disabled-background: #d6d9dd;
   --gcds-input-disabled-text: #545961;
+  --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
   --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
@@ -667,6 +671,7 @@
   --gcds-pagination-hover-background: #d7e5f5;
   --gcds-pagination-hover-text: #0535d2;
   --gcds-pagination-focus-background: #0535d2;
+  --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
   --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -698,6 +703,8 @@
   --gcds-radio-disabled-background: #d6d9dd;
   --gcds-radio-disabled-border: #545961;
   --gcds-radio-disabled-text: #545961;
+  --gcds-radio-focus-background: #ffffff;
+  --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
   --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -727,6 +734,7 @@
   --gcds-select-default-text: #333333;
   --gcds-select-disabled-background: #d6d9dd;
   --gcds-select-disabled-text: #545961;
+  --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
   --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
@@ -752,6 +760,7 @@
   --gcds-textarea-default-text: #333333;
   --gcds-textarea-disabled-background: #d6d9dd;
   --gcds-textarea-disabled-text: #545961;
+  --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
   --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 18:11:33 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:11 GMT
  */
 
 :root {
@@ -135,6 +135,7 @@
   --gcds-button-shared-active-background: #000000;
   --gcds-button-shared-active-text: #ffffff;
   --gcds-button-shared-focus-background: #0535d2;
+  --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.1875rem;
   --gcds-button-shared-focus-text: #ffffff;
   --gcds-button-shared-disabled-background: #d6d9dd;
@@ -179,6 +180,8 @@
   --gcds-checkbox-disabled-border: #545961;
   --gcds-checkbox-disabled-text: #545961;
   --gcds-checkbox-error-padding: 0 0 0 3.75rem;
+  --gcds-checkbox-focus-background: #ffffff;
+  --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
   --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -435,6 +438,7 @@
   --gcds-input-default-text: #333333;
   --gcds-input-disabled-background: #d6d9dd;
   --gcds-input-disabled-text: #545961;
+  --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
   --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
@@ -529,6 +533,7 @@
   --gcds-pagination-hover-background: #d7e5f5;
   --gcds-pagination-hover-text: #0535d2;
   --gcds-pagination-focus-background: #0535d2;
+  --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
   --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -560,6 +565,8 @@
   --gcds-radio-disabled-background: #d6d9dd;
   --gcds-radio-disabled-border: #545961;
   --gcds-radio-disabled-text: #545961;
+  --gcds-radio-focus-background: #ffffff;
+  --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
   --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -589,6 +596,7 @@
   --gcds-select-default-text: #333333;
   --gcds-select-disabled-background: #d6d9dd;
   --gcds-select-disabled-text: #545961;
+  --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
   --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
@@ -614,6 +622,7 @@
   --gcds-textarea-default-text: #333333;
   --gcds-textarea-disabled-background: #d6d9dd;
   --gcds-textarea-disabled-text: #545961;
+  --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
   --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/css/components/button.css
+++ b/build/web/css/components/button.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 22 Jun 2023 14:47:37 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:11 GMT
  */
 
 :root {
@@ -28,6 +28,7 @@
   --gcds-button-shared-active-background: #000000;
   --gcds-button-shared-active-text: #ffffff;
   --gcds-button-shared-focus-background: #0535d2;
+  --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.1875rem;
   --gcds-button-shared-focus-text: #ffffff;
   --gcds-button-shared-disabled-background: #d6d9dd;

--- a/build/web/css/components/checkbox.css
+++ b/build/web/css/components/checkbox.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 17:58:42 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:11 GMT
  */
 
 :root {
@@ -15,6 +15,8 @@
   --gcds-checkbox-disabled-border: #545961;
   --gcds-checkbox-disabled-text: #545961;
   --gcds-checkbox-error-padding: 0 0 0 3.75rem;
+  --gcds-checkbox-focus-background: #ffffff;
+  --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
   --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/components/input.css
+++ b/build/web/css/components/input.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 17:58:42 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -11,6 +11,7 @@
   --gcds-input-default-text: #333333;
   --gcds-input-disabled-background: #d6d9dd;
   --gcds-input-disabled-text: #545961;
+  --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
   --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;

--- a/build/web/css/components/pagination.css
+++ b/build/web/css/components/pagination.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 16 Aug 2023 12:29:55 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -12,6 +12,7 @@
   --gcds-pagination-hover-background: #d7e5f5;
   --gcds-pagination-hover-text: #0535d2;
   --gcds-pagination-focus-background: #0535d2;
+  --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
   --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/components/radio.css
+++ b/build/web/css/components/radio.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 17:58:42 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -14,6 +14,8 @@
   --gcds-radio-disabled-background: #d6d9dd;
   --gcds-radio-disabled-border: #545961;
   --gcds-radio-disabled-text: #545961;
+  --gcds-radio-focus-background: #ffffff;
+  --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
   --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/css/components/select.css
+++ b/build/web/css/components/select.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 17:58:42 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -12,6 +12,7 @@
   --gcds-select-default-text: #333333;
   --gcds-select-disabled-background: #d6d9dd;
   --gcds-select-disabled-text: #545961;
+  --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
   --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;

--- a/build/web/css/components/textarea.css
+++ b/build/web/css/components/textarea.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 17:58:42 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:12 GMT
  */
 
 :root {
@@ -11,6 +11,7 @@
   --gcds-textarea-default-text: #333333;
   --gcds-textarea-disabled-background: #d6d9dd;
   --gcds-textarea-disabled-text: #545961;
+  --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
   --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 17:50:31 GMT
+ * Generated on Wed, 25 Oct 2023 14:27:11 GMT
  */
 
 :root {
@@ -273,6 +273,7 @@
   --gcds-button-shared-active-background: #000000;
   --gcds-button-shared-active-text: #ffffff;
   --gcds-button-shared-focus-background: #0535d2;
+  --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.1875rem;
   --gcds-button-shared-focus-text: #ffffff;
   --gcds-button-shared-disabled-background: #d6d9dd;
@@ -317,6 +318,8 @@
   --gcds-checkbox-disabled-border: #545961;
   --gcds-checkbox-disabled-text: #545961;
   --gcds-checkbox-error-padding: 0 0 0 3.75rem;
+  --gcds-checkbox-focus-background: #ffffff;
+  --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
   --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -484,6 +487,12 @@
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
   --gcds-header-skiptonav-top: 1.5rem;
+  --gcds-heading-character-limit-h1: 31ch;
+  --gcds-heading-character-limit-h2: 35ch;
+  --gcds-heading-character-limit-h3: 40ch;
+  --gcds-heading-character-limit-h4: 45ch;
+  --gcds-heading-character-limit-h5: 50ch;
+  --gcds-heading-character-limit-h6: 57ch;
   --gcds-heading-default-text: #333333;
   --gcds-heading-h1-border-background: #d3080c;
   --gcds-heading-h1-border-height: 0.375rem;
@@ -567,6 +576,7 @@
   --gcds-input-default-text: #333333;
   --gcds-input-disabled-background: #d6d9dd;
   --gcds-input-disabled-text: #545961;
+  --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
   --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
@@ -661,6 +671,7 @@
   --gcds-pagination-hover-background: #d7e5f5;
   --gcds-pagination-hover-text: #0535d2;
   --gcds-pagination-focus-background: #0535d2;
+  --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
   --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -692,6 +703,8 @@
   --gcds-radio-disabled-background: #d6d9dd;
   --gcds-radio-disabled-border: #545961;
   --gcds-radio-disabled-text: #545961;
+  --gcds-radio-focus-background: #ffffff;
+  --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
   --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -721,6 +734,7 @@
   --gcds-select-default-text: #333333;
   --gcds-select-disabled-background: #d6d9dd;
   --gcds-select-disabled-text: #545961;
+  --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
   --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
@@ -746,6 +760,7 @@
   --gcds-textarea-default-text: #333333;
   --gcds-textarea-disabled-background: #d6d9dd;
   --gcds-textarea-disabled-text: #545961;
+  --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
   --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -271,6 +271,7 @@ $gcds-button-mobile-width: 100%;
 $gcds-button-shared-active-background: #000000;
 $gcds-button-shared-active-text: #ffffff;
 $gcds-button-shared-focus-background: #0535d2;
+$gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.1875rem;
 $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
@@ -315,6 +316,8 @@ $gcds-checkbox-disabled-background: #d6d9dd;
 $gcds-checkbox-disabled-border: #545961;
 $gcds-checkbox-disabled-text: #545961;
 $gcds-checkbox-error-padding: 0 0 0 3.75rem;
+$gcds-checkbox-focus-background: #ffffff;
+$gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
 $gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -571,6 +574,7 @@ $gcds-input-default-background: #ffffff;
 $gcds-input-default-text: #333333;
 $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
+$gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
 $gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
@@ -665,6 +669,7 @@ $gcds-pagination-default-text: #2b4380;
 $gcds-pagination-hover-background: #d7e5f5;
 $gcds-pagination-hover-text: #0535d2;
 $gcds-pagination-focus-background: #0535d2;
+$gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
 $gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -696,6 +701,8 @@ $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;
 $gcds-radio-disabled-border: #545961;
 $gcds-radio-disabled-text: #545961;
+$gcds-radio-focus-background: #ffffff;
+$gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
 $gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -725,6 +732,7 @@ $gcds-select-default-background: #ffffff;
 $gcds-select-default-text: #333333;
 $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
+$gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
 $gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
@@ -750,6 +758,7 @@ $gcds-textarea-default-background: #ffffff;
 $gcds-textarea-default-text: #333333;
 $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
+$gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
 $gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
@@ -133,6 +133,7 @@ $gcds-button-mobile-width: 100%;
 $gcds-button-shared-active-background: #000000;
 $gcds-button-shared-active-text: #ffffff;
 $gcds-button-shared-focus-background: #0535d2;
+$gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.1875rem;
 $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
@@ -177,6 +178,8 @@ $gcds-checkbox-disabled-background: #d6d9dd;
 $gcds-checkbox-disabled-border: #545961;
 $gcds-checkbox-disabled-text: #545961;
 $gcds-checkbox-error-padding: 0 0 0 3.75rem;
+$gcds-checkbox-focus-background: #ffffff;
+$gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
 $gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -433,6 +436,7 @@ $gcds-input-default-background: #ffffff;
 $gcds-input-default-text: #333333;
 $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
+$gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
 $gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
@@ -527,6 +531,7 @@ $gcds-pagination-default-text: #2b4380;
 $gcds-pagination-hover-background: #d7e5f5;
 $gcds-pagination-hover-text: #0535d2;
 $gcds-pagination-focus-background: #0535d2;
+$gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
 $gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -558,6 +563,8 @@ $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;
 $gcds-radio-disabled-border: #545961;
 $gcds-radio-disabled-text: #545961;
+$gcds-radio-focus-background: #ffffff;
+$gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
 $gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -587,6 +594,7 @@ $gcds-select-default-background: #ffffff;
 $gcds-select-default-text: #333333;
 $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
+$gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
 $gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
@@ -612,6 +620,7 @@ $gcds-textarea-default-background: #ffffff;
 $gcds-textarea-default-text: #333333;
 $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
+$gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
 $gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/scss/components/button.scss
+++ b/build/web/scss/components/button.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 22 Jun 2023 14:47:37 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-button-border-radius: 0.375rem;
 $gcds-button-border-width: 0.125rem;
@@ -26,6 +26,7 @@ $gcds-button-mobile-width: 100%;
 $gcds-button-shared-active-background: #000000;
 $gcds-button-shared-active-text: #ffffff;
 $gcds-button-shared-focus-background: #0535d2;
+$gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.1875rem;
 $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;

--- a/build/web/scss/components/checkbox.scss
+++ b/build/web/scss/components/checkbox.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 17:58:42 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-checkbox-check-border-width: 0.3125rem;
 $gcds-checkbox-check-height: 1.5rem;
@@ -13,6 +13,8 @@ $gcds-checkbox-disabled-background: #d6d9dd;
 $gcds-checkbox-disabled-border: #545961;
 $gcds-checkbox-disabled-text: #545961;
 $gcds-checkbox-error-padding: 0 0 0 3.75rem;
+$gcds-checkbox-focus-background: #ffffff;
+$gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
 $gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/components/input.scss
+++ b/build/web/scss/components/input.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 17:58:42 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-input-border-radius: 0.1875rem;
 $gcds-input-border-width: 0.125rem;
@@ -9,6 +9,7 @@ $gcds-input-default-background: #ffffff;
 $gcds-input-default-text: #333333;
 $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
+$gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
 $gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;

--- a/build/web/scss/components/pagination.scss
+++ b/build/web/scss/components/pagination.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 16 Aug 2023 12:29:54 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-pagination-active-text: #ffffff;
 $gcds-pagination-active-background: #26374a;
@@ -10,6 +10,7 @@ $gcds-pagination-default-text: #2b4380;
 $gcds-pagination-hover-background: #d7e5f5;
 $gcds-pagination-hover-text: #0535d2;
 $gcds-pagination-focus-background: #0535d2;
+$gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
 $gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/components/radio.scss
+++ b/build/web/scss/components/radio.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 17:58:42 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
@@ -12,6 +12,8 @@ $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;
 $gcds-radio-disabled-border: #545961;
 $gcds-radio-disabled-text: #545961;
+$gcds-radio-focus-background: #ffffff;
+$gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
 $gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;

--- a/build/web/scss/components/select.scss
+++ b/build/web/scss/components/select.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 17:58:42 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-select-arrow-position-x: calc(100% - 0.75rem);
 $gcds-select-border-radius: 0.1875rem;
@@ -10,6 +10,7 @@ $gcds-select-default-background: #ffffff;
 $gcds-select-default-text: #333333;
 $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
+$gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
 $gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;

--- a/build/web/scss/components/textarea.scss
+++ b/build/web/scss/components/textarea.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 17:58:42 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-textarea-border-radius: 0.1875rem;
 $gcds-textarea-border-width: 0.125rem;
@@ -9,6 +9,7 @@ $gcds-textarea-default-background: #ffffff;
 $gcds-textarea-default-text: #333333;
 $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
+$gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
 $gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 14:27:11 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -271,6 +271,7 @@ $gcds-button-mobile-width: 100%;
 $gcds-button-shared-active-background: #000000;
 $gcds-button-shared-active-text: #ffffff;
 $gcds-button-shared-focus-background: #0535d2;
+$gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.1875rem;
 $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
@@ -315,6 +316,8 @@ $gcds-checkbox-disabled-background: #d6d9dd;
 $gcds-checkbox-disabled-border: #545961;
 $gcds-checkbox-disabled-text: #545961;
 $gcds-checkbox-error-padding: 0 0 0 3.75rem;
+$gcds-checkbox-focus-background: #ffffff;
+$gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
 $gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -571,6 +574,7 @@ $gcds-input-default-background: #ffffff;
 $gcds-input-default-text: #333333;
 $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
+$gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
 $gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
@@ -665,6 +669,7 @@ $gcds-pagination-default-text: #2b4380;
 $gcds-pagination-hover-background: #d7e5f5;
 $gcds-pagination-hover-text: #0535d2;
 $gcds-pagination-focus-background: #0535d2;
+$gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
 $gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
@@ -696,6 +701,8 @@ $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;
 $gcds-radio-disabled-border: #545961;
 $gcds-radio-disabled-text: #545961;
+$gcds-radio-focus-background: #ffffff;
+$gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
 $gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -725,6 +732,7 @@ $gcds-select-default-background: #ffffff;
 $gcds-select-default-text: #333333;
 $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
+$gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
 $gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
@@ -750,6 +758,7 @@ $gcds-textarea-default-background: #ffffff;
 $gcds-textarea-default-text: #333333;
 $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
+$gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
 $gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/button/tokens.json
+++ b/tokens/components/button/tokens.json
@@ -139,6 +139,10 @@
           "value": "{focus.background.value}",
           "type": "color"
         },
+        "box-shadow": {
+          "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+          "type": "color"
+        },
         "outline": {
           "width": {
             "value": "{outline.width.value}",

--- a/tokens/components/checkbox/tokens.json
+++ b/tokens/components/checkbox/tokens.json
@@ -57,6 +57,14 @@
       }
     },
     "focus": {
+      "background": {
+        "value": "{color.grayscale.0.value}",
+        "type": "color"
+      },
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.textForm.value}",
         "type": "color"

--- a/tokens/components/input/tokens.json
+++ b/tokens/components/input/tokens.json
@@ -37,6 +37,10 @@
       }
     },
     "focus": {
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.textForm.value}",
         "type": "color"

--- a/tokens/components/pagination/tokens.json
+++ b/tokens/components/pagination/tokens.json
@@ -41,6 +41,10 @@
         "value": "{focus.background.value}",
         "type": "color"
       },
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.text.value}",
         "type": "color"

--- a/tokens/components/radio/tokens.json
+++ b/tokens/components/radio/tokens.json
@@ -53,6 +53,14 @@
       }
     },
     "focus": {
+      "background": {
+        "value": "{color.grayscale.0.value}",
+        "type": "color"
+      },
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.textForm.value}",
         "type": "color"

--- a/tokens/components/select/tokens.json
+++ b/tokens/components/select/tokens.json
@@ -43,6 +43,10 @@
       }
     },
     "focus": {
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.textForm.value}",
         "type": "color"

--- a/tokens/components/textarea/tokens.json
+++ b/tokens/components/textarea/tokens.json
@@ -37,6 +37,10 @@
       }
     },
     "focus": {
+      "box-shadow": {
+        "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
+        "type": "color"
+      },
       "text": {
         "value": "{focus.textForm.value}",
         "type": "color"


### PR DESCRIPTION
# Summary | Résumé

Add a box-shadow to multiple components to have consistent styling. Based on decision from Dev/Design sync on August 1st.

Updated component tokes:
- Button
- Checkbox
- Input
- Radio
- Pagination
- Select
- Textarea
