### PR TITLE
chore: adds more design tokens for the link component

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -260,6 +260,12 @@
           },
           "type": "typography"
         }
+      },
+      "decoration": {
+        "thickness": {
+          "value": "0.0625rem",
+          "type": "borderWidth"
+        }
       }
     },
     "text": {

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -235,9 +235,19 @@
             "type": "other"
           }
         },
+        "outline-offset": {
+          "value": "0.125rem",
+          "type": "spacing"
+        },
         "text": {
           "value": "#FFF",
           "type": "color"
+        },
+        "border": {
+          "color": {
+            "value": "#0535d2",
+            "type": "color"
+          }
         }
       },
       "small": {

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 18:11:33 GMT
+ * Generated on Wed, 25 Oct 2023 20:42:19 GMT
  */
 
 :root {
@@ -54,7 +54,9 @@
   --gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-link-focus-background: #0535d2;
   --gcds-link-focus-outline-width: 0.1875rem;
+  --gcds-link-focus-outline-offset: 0.125rem;
   --gcds-link-focus-text: #ffffff;
+  --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-text-light: #ffffff; /* Global color: text light */
   --gcds-text-primary: #333333; /* Global color: text primary */

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Oct 2023 20:42:19 GMT
+ * Generated on Wed, 25 Oct 2023 22:37:21 GMT
  */
 
 :root {
@@ -58,6 +58,7 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-text-light: #ffffff; /* Global color: text light */
   --gcds-text-primary: #333333; /* Global color: text primary */
   --gcds-text-secondary: #43474e; /* Global color: text secondary */

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,13 +1,15 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 18:11:33 GMT
+ * Generated on Wed, 25 Oct 2023 20:42:19 GMT
  */
 
 :root {
   --gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-link-focus-background: #0535d2;
   --gcds-link-focus-outline-width: 0.1875rem;
+  --gcds-link-focus-outline-offset: 0.125rem;
   --gcds-link-focus-text: #ffffff;
+  --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-text-character-limit: 65ch;
   --gcds-text-role-light: #ffffff;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Oct 2023 20:42:19 GMT
+ * Generated on Wed, 25 Oct 2023 22:37:20 GMT
  */
 
 :root {
@@ -11,6 +11,7 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-text-character-limit: 65ch;
   --gcds-text-role-light: #ffffff;
   --gcds-text-role-primary: #333333;

--- a/build/web/css/components/link.css
+++ b/build/web/css/components/link.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Oct 2023 20:42:19 GMT
+ * Generated on Wed, 25 Oct 2023 22:37:21 GMT
  */
 
 :root {
@@ -11,4 +11,5 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-decoration-thickness: 0.0625rem;
 }

--- a/build/web/css/components/link.css
+++ b/build/web/css/components/link.css
@@ -1,12 +1,14 @@
 /**
  * Do not edit directly
- * Generated on Fri, 13 Oct 2023 21:38:05 GMT
+ * Generated on Wed, 25 Oct 2023 20:42:19 GMT
  */
 
 :root {
   --gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-link-focus-background: #0535d2;
   --gcds-link-focus-outline-width: 0.1875rem;
+  --gcds-link-focus-outline-offset: 0.125rem;
   --gcds-link-focus-text: #ffffff;
+  --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 19 Oct 2023 17:50:31 GMT
+ * Generated on Wed, 25 Oct 2023 20:42:19 GMT
  */
 
 :root {
@@ -54,7 +54,9 @@
   --gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-link-focus-background: #0535d2;
   --gcds-link-focus-outline-width: 0.1875rem;
+  --gcds-link-focus-outline-offset: 0.125rem;
   --gcds-link-focus-text: #ffffff;
+  --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-text-light: #ffffff; /* Global color: text light */
   --gcds-text-primary: #333333; /* Global color: text primary */
@@ -484,6 +486,12 @@
   --gcds-header-container-max-width: 71.25rem;
   --gcds-header-margin: 0 0 0.75rem;
   --gcds-header-skiptonav-top: 1.5rem;
+  --gcds-heading-character-limit-h1: 31ch;
+  --gcds-heading-character-limit-h2: 35ch;
+  --gcds-heading-character-limit-h3: 40ch;
+  --gcds-heading-character-limit-h4: 45ch;
+  --gcds-heading-character-limit-h5: 50ch;
+  --gcds-heading-character-limit-h6: 57ch;
   --gcds-heading-default-text: #333333;
   --gcds-heading-h1-border-background: #d3080c;
   --gcds-heading-h1-border-height: 0.375rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Oct 2023 20:42:19 GMT
+ * Generated on Wed, 25 Oct 2023 22:37:20 GMT
  */
 
 :root {
@@ -58,6 +58,7 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-color: #0535d2;
   --gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-text-light: #ffffff; /* Global color: text light */
   --gcds-text-primary: #333333; /* Global color: text primary */
   --gcds-text-secondary: #43474e; /* Global color: text secondary */

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 25 Oct 2023 20:42:19 GMT
+// Generated on Wed, 25 Oct 2023 22:37:20 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -56,6 +56,7 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-decoration-thickness: 0.0625rem;
 $gcds-text-light: #ffffff; // Global color: text light
 $gcds-text-primary: #333333; // Global color: text primary
 $gcds-text-secondary: #43474e; // Global color: text secondary

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 20:42:19 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -52,7 +52,9 @@ $gcds-link-light: #ffffff; // Global color: link light
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
+$gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
+$gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-text-light: #ffffff; // Global color: text light
 $gcds-text-primary: #333333; // Global color: text primary

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 25 Oct 2023 20:42:19 GMT
+// Generated on Wed, 25 Oct 2023 22:37:20 GMT
 
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
@@ -9,6 +9,7 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-decoration-thickness: 0.0625rem;
 $gcds-text-character-limit: 65ch;
 $gcds-text-role-light: #ffffff;
 $gcds-text-role-primary: #333333;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,11 +1,13 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 20:42:19 GMT
 
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
+$gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
+$gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-text-character-limit: 65ch;
 $gcds-text-role-light: #ffffff;

--- a/build/web/scss/components/link.scss
+++ b/build/web/scss/components/link.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 25 Oct 2023 20:42:19 GMT
+// Generated on Wed, 25 Oct 2023 22:37:20 GMT
 
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
@@ -9,3 +9,4 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-decoration-thickness: 0.0625rem;

--- a/build/web/scss/components/link.scss
+++ b/build/web/scss/components/link.scss
@@ -1,9 +1,11 @@
 
 // Do not edit directly
-// Generated on Fri, 13 Oct 2023 21:38:05 GMT
+// Generated on Wed, 25 Oct 2023 20:42:19 GMT
 
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
+$gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
+$gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 25 Oct 2023 20:42:19 GMT
+// Generated on Wed, 25 Oct 2023 22:37:20 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -56,6 +56,7 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-decoration-thickness: 0.0625rem;
 $gcds-text-light: #ffffff; // Global color: text light
 $gcds-text-primary: #333333; // Global color: text primary
 $gcds-text-secondary: #43474e; // Global color: text secondary

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 19 Oct 2023 18:11:33 GMT
+// Generated on Wed, 25 Oct 2023 20:42:19 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -52,7 +52,9 @@ $gcds-link-light: #ffffff; // Global color: link light
 $gcds-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
+$gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
+$gcds-link-focus-border-color: #0535d2;
 $gcds-link-small-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-text-light: #ffffff; // Global color: text light
 $gcds-text-primary: #333333; // Global color: text primary

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cdssnc/gcds-tokens",
-  "version": "1.10.0",
+  "version": "1.9.1",
   "author": "Government of Canada | Gouvernement du Canada",
   "description": "GC Design System Tokens",
   "homepage": "https://design-system.alpha.canada.ca/",

--- a/tokens/components/link/tokens.json
+++ b/tokens/components/link/tokens.json
@@ -46,16 +46,10 @@
         "type": "typography"
       }
     },
-    "default": {
-      "decoration": {
-        "thickness": {
-          "value": "{border.width.sm.value}",
-          "type": "borderWidth"
-        }
-      },
-      "background": {
-        "value": "transparent",
-        "type": "color"
+    "decoration": {
+      "thickness": {
+        "value": "{border.width.sm.value}",
+        "type": "borderWidth"
       }
     }
   }

--- a/tokens/components/link/tokens.json
+++ b/tokens/components/link/tokens.json
@@ -20,9 +20,19 @@
           "type": "other"
         }
       },
+      "outline-offset": {
+        "value": "{border.width.md.value}",
+        "type": "spacing"
+      },
       "text": {
         "value": "{focus.text.value}",
         "type": "color"
+      },
+      "border": {
+        "color": {
+          "value": "{focus.background.value}",
+          "type": "color"
+        }
       }
     },
     "small": {
@@ -34,6 +44,18 @@
           "fontSize": "{fontSizes.caption}"
         },
         "type": "typography"
+      }
+    },
+    "default": {
+      "decoration": {
+        "thickness": {
+          "value": "{border.width.sm.value}",
+          "type": "borderWidth"
+        }
+      },
+      "background": {
+        "value": "transparent",
+        "type": "color"
       }
     }
   }


### PR DESCRIPTION
# Summary | Résumé

This adds more tokens needed for the Link component.

Also got rid of the `active` styles because @nmakuch has confirmed that links would not contain styling for active state

This PR:
- [x] Only contains changed files
- [x] Update package version