### PR TITLE
fix: give `npm publish` time to complete

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
           PUBLISHED_PACKAGE="${{ steps.publish.outputs.id }}"
 
           mkdir -p ./tmp \
+            && sleep 60 \
             && npm install --prefix ./tmp "$PUBLISHED_PACKAGE" \
             && cd ./tmp/node_modules
 


### PR DESCRIPTION
# Summary
Update the CDN publish step to sleep for `60s` so that the npm publish has time to complete.