### PR TITLE
fix: Remove error summary link tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1933,32 +1933,6 @@
         "color": {
           "value": "#0535d2",
           "type": "color"
-        },
-        "link": {
-          "backgroundColor": {
-            "value": "#0535d2",
-            "type": "color"
-          },
-          "borderRadius": {
-            "value": "0.1875rem",
-            "type": "other"
-          },
-          "boxShadow": {
-            "value": "0 0 0 0.125rem #FFF",
-            "type": "other"
-          },
-          "outline": {
-            "value": "0.1875rem solid #0535d2",
-            "type": "other"
-          },
-          "outlineOffset": {
-            "value": "0.125rem",
-            "type": "borderWidth"
-          },
-          "text": {
-            "value": "#FFF",
-            "type": "color"
-          }
         }
       },
       "heading": {
@@ -1974,24 +1948,6 @@
         "paddingBottom": {
           "value": "1.125rem",
           "type": "spacing"
-        }
-      },
-      "hover": {
-        "link": {
-          "thickness": {
-            "value": "0.125rem",
-            "type": "borderWidth"
-          }
-        }
-      },
-      "link": {
-        "color": {
-          "value": "#A62A1E",
-          "type": "color"
-        },
-        "thickness": {
-          "value": "0.0625rem",
-          "type": "borderWidth"
         }
       },
       "list": {
@@ -2461,71 +2417,25 @@
       }
     },
     "grid": {
-      "gap": {
-        "0": {
-          "value": "0",
-          "type": "spacing"
-        },
-        "50": {
-          "value": "0.1875rem",
-          "type": "spacing"
-        },
-        "100": {
-          "value": "0.375rem",
-          "type": "spacing"
-        },
-        "150": {
-          "value": "0.5625rem",
-          "type": "spacing"
-        },
-        "200": {
-          "value": "0.75rem",
-          "type": "spacing"
-        },
-        "250": {
-          "value": "0.9375rem",
-          "type": "spacing"
-        },
-        "300": {
-          "value": "1.125rem",
-          "type": "spacing"
-        },
-        "400": {
-          "value": "1.5rem",
-          "type": "spacing"
-        },
-        "450": {
-          "value": "2.25rem",
-          "type": "spacing"
-        },
-        "500": {
-          "value": "3rem",
-          "type": "spacing"
-        },
-        "550": {
-          "value": "3.75rem",
-          "type": "spacing"
-        },
-        "600": {
-          "value": "4.5rem",
-          "type": "spacing"
-        },
-        "700": {
-          "value": "6rem",
-          "type": "spacing"
-        },
-        "800": {
-          "value": "7.5rem",
-          "type": "spacing"
-        },
-        "900": {
-          "value": "9rem",
-          "type": "spacing"
-        },
-        "1000": {
-          "value": "10.5rem",
-          "type": "spacing"
+      "columns": {
+        "default": {
+          "base": {
+            "value": 1,
+            "type": "sizing"
+          },
+          "tablet": {
+            "value": 6,
+            "type": "sizing"
+          },
+          "desktop": {
+            "value": 12,
+            "type": "sizing"
+          }
         }
+      },
+      "gap": {
+        "value": "3rem",
+        "type": "spacing"
       }
     },
     "header": {

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Nov 2023 22:36:35 GMT
+ * Generated on Thu, 01 Feb 2024 20:29:48 GMT
  */
 
 :root {
@@ -372,17 +372,8 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
   --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Nov 2023 22:36:34 GMT
+ * Generated on Thu, 01 Feb 2024 20:29:47 GMT
  */
 
 :root {
@@ -234,17 +234,8 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
   --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/components/error-summary.css
+++ b/build/web/css/components/error-summary.css
@@ -1,23 +1,14 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 23:02:42 GMT
+ * Generated on Thu, 01 Feb 2024 20:29:47 GMT
  */
 
 :root {
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
   --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Nov 2023 22:36:34 GMT
+ * Generated on Thu, 01 Feb 2024 20:29:47 GMT
  */
 
 :root {
@@ -372,17 +372,8 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
   --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Nov 2023 22:36:34 GMT
+// Generated on Thu, 01 Feb 2024 20:29:47 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -370,17 +370,8 @@ $gcds-error-message-text: #333333;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
 $gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Nov 2023 22:36:34 GMT
+// Generated on Thu, 01 Feb 2024 20:29:47 GMT
 
 $gcds-link-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-link-font-regular: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -232,17 +232,8 @@ $gcds-error-message-text: #333333;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
 $gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components/error-summary.scss
+++ b/build/web/scss/components/error-summary.scss
@@ -1,21 +1,12 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 23:02:42 GMT
+// Generated on Thu, 01 Feb 2024 20:29:47 GMT
 
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
 $gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Nov 2023 22:36:33 GMT
+// Generated on Thu, 01 Feb 2024 20:29:47 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -370,17 +370,8 @@ $gcds-error-message-text: #333333;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
 $gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/tokens/components/error-summary/tokens.json
+++ b/tokens/components/error-summary/tokens.json
@@ -14,32 +14,6 @@
       "color": {
         "value": "{focus.textForm.value}",
         "type": "color"
-      },
-      "link": {
-        "backgroundColor": {
-          "value": "{focus.background.value}",
-          "type": "color"
-        },
-        "borderRadius": {
-          "value": "{border.radius.sm.value}",
-          "type": "other"
-        },
-        "boxShadow": {
-          "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
-          "type": "other"
-        },
-        "outline": {
-          "value": "{spacing.50.value} solid {focus.background.value}",
-          "type": "other"
-        },
-        "outlineOffset": {
-          "value": "{border.width.md.value}",
-          "type": "borderWidth"
-        },
-        "text": {
-          "value": "{focus.text.value}",
-          "type": "color"
-        }
       }
     },
     "heading": {
@@ -55,24 +29,6 @@
       "paddingBottom": {
         "value": "{spacing.300.value}",
         "type": "spacing"
-      }
-    },
-    "hover": {
-      "link": {
-        "thickness": {
-          "value": "{border.width.md.value}",
-          "type": "borderWidth"
-        }
-      }
-    },
-    "link": {
-      "color": {
-        "value": "{color.red.700.value}",
-        "type": "color"
-      },
-      "thickness": {
-        "value": "{border.width.sm.value}",
-        "type": "borderWidth"
       }
     },
     "list": {


### PR DESCRIPTION
# Summary | Résumé

Remove `gcds-error-summery` link tokens as we are now using the `gcds-link` in the error summary component.

**Note:** Will merge closer to launch of `gcds-components-ssr` package.
