### PR TITLE
refactor: remove redundant tokens after integrating gcds-heading into existing components

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1758,65 +1758,6 @@
         "color": {
           "value": "#0535d2",
           "type": "color"
-        },
-        "link": {
-          "backgroundColor": {
-            "value": "#0535d2",
-            "type": "color"
-          },
-          "borderRadius": {
-            "value": "0.1875rem",
-            "type": "other"
-          },
-          "boxShadow": {
-            "value": "0 0 0 0.125rem #FFF",
-            "type": "other"
-          },
-          "outline": {
-            "value": "0.1875rem solid #0535d2",
-            "type": "other"
-          },
-          "outlineOffset": {
-            "value": "0.125rem",
-            "type": "borderWidth"
-          },
-          "text": {
-            "value": "#FFF",
-            "type": "color"
-          }
-        }
-      },
-      "heading": {
-        "font": {
-          "value": {
-            "fontFamily": "\"Lato\", sans-serif",
-            "fontWeight": "700",
-            "lineHeight": "122.08437060746162%",
-            "fontSize": "2.2525405883789062rem"
-          },
-          "type": "typography"
-        },
-        "paddingBottom": {
-          "value": "1.125rem",
-          "type": "spacing"
-        }
-      },
-      "hover": {
-        "link": {
-          "thickness": {
-            "value": "0.125rem",
-            "type": "borderWidth"
-          }
-        }
-      },
-      "link": {
-        "color": {
-          "value": "#A62A1E",
-          "type": "color"
-        },
-        "thickness": {
-          "value": "0.0625rem",
-          "type": "borderWidth"
         }
       },
       "list": {

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3634,19 +3634,6 @@
       }
     },
     "stepper": {
-      "font": {
-        "value": {
-          "fontFamily": "\"Lato\", sans-serif",
-          "fontWeight": "600",
-          "lineHeight": "124.44444444444444%",
-          "fontSize": "1.40625rem"
-        },
-        "type": "typography"
-      },
-      "margin": {
-        "value": "0 0 1.125rem",
-        "type": "spacing"
-      },
       "text": {
         "value": "#43474E",
         "type": "color"

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 27 Feb 2024 01:06:07 GMT
+ * Generated on Thu, 29 Feb 2024 19:14:54 GMT
  */
 
 :root {
@@ -339,17 +339,6 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-  --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 19:14:54 GMT
+ * Generated on Thu, 29 Feb 2024 21:29:37 GMT
  */
 
 :root {
@@ -678,8 +678,6 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-  --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
   --gcds-textarea-border-width: 0.125rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 27 Feb 2024 01:06:07 GMT
+ * Generated on Thu, 29 Feb 2024 19:14:54 GMT
  */
 
 :root {
@@ -201,17 +201,6 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-  --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 19:14:54 GMT
+ * Generated on Thu, 29 Feb 2024 21:29:37 GMT
  */
 
 :root {
@@ -540,8 +540,6 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-  --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
   --gcds-textarea-border-width: 0.125rem;

--- a/build/web/css/components/error-summary.css
+++ b/build/web/css/components/error-summary.css
@@ -1,23 +1,12 @@
 /**
  * Do not edit directly
- * Generated on Thu, 20 Jul 2023 23:02:42 GMT
+ * Generated on Thu, 29 Feb 2024 19:14:54 GMT
  */
 
 :root {
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-  --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/components/stepper.css
+++ b/build/web/css/components/stepper.css
@@ -1,10 +1,8 @@
 /**
  * Do not edit directly
- * Generated on Mon, 19 Jun 2023 20:28:18 GMT
+ * Generated on Thu, 29 Feb 2024 21:29:37 GMT
  */
 
 :root {
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-  --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 27 Feb 2024 01:06:07 GMT
+ * Generated on Thu, 29 Feb 2024 19:14:54 GMT
  */
 
 :root {
@@ -339,17 +339,6 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
-  --gcds-error-summary-focus-link-background-color: #0535d2;
-  --gcds-error-summary-focus-link-border-radius: 0.1875rem;
-  --gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-  --gcds-error-summary-focus-link-outline-offset: 0.125rem;
-  --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-  --gcds-error-summary-heading-padding-bottom: 1.125rem;
-  --gcds-error-summary-hover-link-thickness: 0.125rem;
-  --gcds-error-summary-link-color: #a62a1e;
-  --gcds-error-summary-link-thickness: 0.0625rem;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 19:14:54 GMT
+ * Generated on Thu, 29 Feb 2024 21:29:37 GMT
  */
 
 :root {
@@ -678,8 +678,6 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-  --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
   --gcds-textarea-border-width: 0.125rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 29 Feb 2024 19:14:54 GMT
+// Generated on Thu, 29 Feb 2024 21:29:37 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -676,8 +676,6 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-$gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
 $gcds-textarea-border-width: 0.125rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 27 Feb 2024 01:06:06 GMT
+// Generated on Thu, 29 Feb 2024 19:14:54 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -337,17 +337,6 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-$gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 27 Feb 2024 01:06:06 GMT
+// Generated on Thu, 29 Feb 2024 19:14:54 GMT
 
 $gcds-link-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-link-font-regular: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -199,17 +199,6 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-$gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 29 Feb 2024 19:14:54 GMT
+// Generated on Thu, 29 Feb 2024 21:29:37 GMT
 
 $gcds-link-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-link-font-regular: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -538,8 +538,6 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-$gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
 $gcds-textarea-border-width: 0.125rem;

--- a/build/web/scss/components/error-summary.scss
+++ b/build/web/scss/components/error-summary.scss
@@ -1,21 +1,10 @@
 
 // Do not edit directly
-// Generated on Thu, 20 Jul 2023 23:02:42 GMT
+// Generated on Thu, 29 Feb 2024 19:14:54 GMT
 
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-$gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components/stepper.scss
+++ b/build/web/scss/components/stepper.scss
@@ -1,7 +1,5 @@
 
 // Do not edit directly
-// Generated on Mon, 19 Jun 2023 20:28:18 GMT
+// Generated on Thu, 29 Feb 2024 21:29:37 GMT
 
-$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-$gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 29 Feb 2024 19:14:54 GMT
+// Generated on Thu, 29 Feb 2024 21:29:37 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -676,8 +676,6 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
-$gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
 $gcds-textarea-border-width: 0.125rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 27 Feb 2024 01:06:06 GMT
+// Generated on Thu, 29 Feb 2024 19:14:54 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -337,17 +337,6 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
-$gcds-error-summary-focus-link-background-color: #0535d2;
-$gcds-error-summary-focus-link-border-radius: 0.1875rem;
-$gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
-$gcds-error-summary-focus-link-outline-offset: 0.125rem;
-$gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
-$gcds-error-summary-heading-padding-bottom: 1.125rem;
-$gcds-error-summary-hover-link-thickness: 0.125rem;
-$gcds-error-summary-link-color: #a62a1e;
-$gcds-error-summary-link-thickness: 0.0625rem;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/tokens/components/error-summary/tokens.json
+++ b/tokens/components/error-summary/tokens.json
@@ -14,65 +14,6 @@
       "color": {
         "value": "{focus.textForm.value}",
         "type": "color"
-      },
-      "link": {
-        "backgroundColor": {
-          "value": "{focus.background.value}",
-          "type": "color"
-        },
-        "borderRadius": {
-          "value": "{border.radius.sm.value}",
-          "type": "other"
-        },
-        "boxShadow": {
-          "value": "0 0 0 {border.width.md.value} {color.grayscale.0.value}",
-          "type": "other"
-        },
-        "outline": {
-          "value": "{spacing.50.value} solid {focus.background.value}",
-          "type": "other"
-        },
-        "outlineOffset": {
-          "value": "{border.width.md.value}",
-          "type": "borderWidth"
-        },
-        "text": {
-          "value": "{focus.text.value}",
-          "type": "color"
-        }
-      }
-    },
-    "heading": {
-      "font": {
-        "value": {
-          "fontFamily": "{fontFamilies.heading}",
-          "fontWeight": "{fontWeights.bold}",
-          "lineHeight": "{lineHeights.h2}",
-          "fontSize": "{fontSizes.h2}"
-        },
-        "type": "typography"
-      },
-      "paddingBottom": {
-        "value": "{spacing.300.value}",
-        "type": "spacing"
-      }
-    },
-    "hover": {
-      "link": {
-        "thickness": {
-          "value": "{border.width.md.value}",
-          "type": "borderWidth"
-        }
-      }
-    },
-    "link": {
-      "color": {
-        "value": "{color.red.700.value}",
-        "type": "color"
-      },
-      "thickness": {
-        "value": "{border.width.sm.value}",
-        "type": "borderWidth"
       }
     },
     "list": {

--- a/tokens/components/stepper/tokens.json
+++ b/tokens/components/stepper/tokens.json
@@ -1,18 +1,5 @@
 {
   "stepper": {
-    "font": {
-      "value": {
-        "fontFamily": "{fontFamilies.heading}",
-        "fontWeight": "{fontWeights.semibold}",
-        "lineHeight": "{lineHeights.h6}",
-        "fontSize": "{fontSizes.h6}"
-      },
-      "type": "typography"
-    },
-    "margin": {
-      "value": "0 0 {spacing.300.value}",
-      "type": "spacing"
-    },
     "text": {
       "value": "{text.secondary.value}",
       "type": "color"


### PR DESCRIPTION
# Summary | Résumé

Remove redundant tokens after integrating `gcds-heading` component into existing components to reduce code duplication created through repeated text styles.

`gcds-heading` was integrated into:

- gcds-error-summary
- gcds-stepper