### PR TITLE
fix: naming convention from global focus-text-form token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -197,7 +197,7 @@
         "value": "#FFF",
         "type": "color"
       },
-      "textForm": {
+      "text-form": {
         "value": "#0535d2",
         "type": "color"
       }

--- a/tokens/components/checkbox/tokens.json
+++ b/tokens/components/checkbox/tokens.json
@@ -66,7 +66,7 @@
         "type": "color"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       },
       "outline": {

--- a/tokens/components/error-summary/tokens.json
+++ b/tokens/components/error-summary/tokens.json
@@ -12,7 +12,7 @@
     },
     "focus": {
       "color": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       },
       "link": {

--- a/tokens/components/fieldset/tokens.json
+++ b/tokens/components/fieldset/tokens.json
@@ -14,7 +14,7 @@
     },
     "focus": {
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/components/file-uploader/tokens.json
+++ b/tokens/components/file-uploader/tokens.json
@@ -171,7 +171,7 @@
         }
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/components/input/tokens.json
+++ b/tokens/components/input/tokens.json
@@ -42,7 +42,7 @@
         "type": "color"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/components/radio/tokens.json
+++ b/tokens/components/radio/tokens.json
@@ -62,7 +62,7 @@
         "type": "color"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       },
       "outline": {

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -32,7 +32,7 @@
         "type": "other"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/components/select/tokens.json
+++ b/tokens/components/select/tokens.json
@@ -48,7 +48,7 @@
         "type": "color"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/components/textarea/tokens.json
+++ b/tokens/components/textarea/tokens.json
@@ -42,7 +42,7 @@
         "type": "color"
       },
       "text": {
-        "value": "{focus.textForm.value}",
+        "value": "{focus.text-form.value}",
         "type": "color"
       }
     },

--- a/tokens/global/color/tokens.json
+++ b/tokens/global/color/tokens.json
@@ -58,7 +58,7 @@
       "type": "color",
       "comment": "Global color: focus text"
     },
-    "textForm": {
+    "text-form": {
       "value": "{color.blue.850.value}",
       "type": "color",
       "comment": "Global color: focus text form elements"


### PR DESCRIPTION
# Summary | Résumé

Remove camel case naming convention from global `focus-text-form` token to match other tokens.