### PR TITLE
feat: add global background tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -164,6 +164,28 @@
         "type": "color"
       }
     },
+    "bg": {
+      "black": {
+        "value": "#000",
+        "type": "color"
+      },
+      "dark": {
+        "value": "#333333",
+        "type": "color"
+      },
+      "light": {
+        "value": "#F1F2F3",
+        "type": "color"
+      },
+      "primary": {
+        "value": "#26374A",
+        "type": "color"
+      },
+      "white": {
+        "value": "#FFF",
+        "type": "color"
+      }
+    },
     "danger": {
       "background": {
         "value": "#FBDDDA",
@@ -3653,7 +3675,7 @@
       },
       "secondary": {
         "background": {
-          "value": "#D6D9DD",
+          "value": "#F1F2F3",
           "type": "color"
         },
         "text": {
@@ -4493,7 +4515,7 @@
     },
     "verify-banner": {
       "background": {
-        "value": "#D6D9DD",
+        "value": "#F1F2F3",
         "type": "color"
       },
       "container": {

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 04 Apr 2024 18:09:58 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
@@ -40,6 +40,11 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
+  --gcds-bg-black: #000000; /* Global bg color: black background */
+  --gcds-bg-dark: #333333; /* Global bg color: dark background */
+  --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
+  --gcds-bg-primary: #26374a; /* Global bg color: primary background */
+  --gcds-bg-white: #ffffff; /* Global bg color: white background */
   --gcds-danger-background: #fbddda; /* Global color: danger background */
   --gcds-danger-border: #d3080c; /* Global color: danger border */
   --gcds-danger-text: #a62a1e; /* Global color: danger text */
@@ -57,12 +62,10 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-radius: 0.1875rem;
   --gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-regular-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-link-font-regular-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
   --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-link-underline-offset: 0.25rem;
   --gcds-text-light: #ffffff; /* Global color: text light */
@@ -72,13 +75,10 @@
   --gcds-text-role-light: #ffffff;
   --gcds-text-role-primary: #333333;
   --gcds-text-role-secondary: #43474e;
-  --gcds-text-size-body-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-text-size-body-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625%
-      'Noto Sans',
-    sans-serif;
+  --gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
   --gcds-text-spacing-0: 0;
   --gcds-text-spacing-50: 0.1875rem;
   --gcds-text-spacing-100: 0.375rem;
@@ -146,10 +146,10 @@
   --gcds-base-font-size-mobile: 1; /* Sets base font size for smaller screens to 16px */
   --gcds-base-line-height: 1.2; /* Sets base line height to 24px */
   --gcds-base-scale: 1.125;
-  --gcds-font-families-heading: 'Lato', sans-serif;
-  --gcds-font-families-body: 'Noto Sans', sans-serif;
-  --gcds-font-families-monospace: 'Menlo', sans-serif;
-  --gcds-font-families-icons: 'Font Awesome 6 Free', FontAwesome;
+  --gcds-font-families-heading: "Lato", sans-serif;
+  --gcds-font-families-body: "Noto Sans", sans-serif;
+  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;
   --gcds-font-sizes-text: 1.25rem;
@@ -187,33 +187,26 @@
   --gcds-line-heights-h2-mobile: 124.85901539399481%;
   --gcds-line-heights-h1: 118.38484422541731%;
   --gcds-line-heights-h1-mobile: 123.31754606814303%;
-  --gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% 'Lato',
-    sans-serif;
-  --gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% 'Lato',
-    sans-serif;
-  --gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% 'Lato',
-    sans-serif;
-  --gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% 'Lato', sans-serif;
-  --gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-font-h4: 700 1.77978515625rem/126.41975308641973% 'Lato', sans-serif;
-  --gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% 'Lato',
-    sans-serif;
-  --gcds-font-h5: 700 1.58203125rem/126.41975308641975% 'Lato', sans-serif;
-  --gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% 'Lato', sans-serif;
-  --gcds-font-h6: 700 1.40625rem/124.44444444444444% 'Lato', sans-serif;
-  --gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-caption: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
-  --gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% 'Noto Sans',
-    sans-serif;
-  --gcds-font-text: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-font-text-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-text-long: 400 1.25rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-text-long-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+  --gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+  --gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+  --gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-font-h4: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+  --gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+  --gcds-font-h5: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+  --gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+  --gcds-font-h6: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+  --gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
+  --gcds-font-label: 500 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-font-label-mobile: 500 1rem/150% "Noto Sans", sans-serif;
+  --gcds-font-caption: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+  --gcds-font-text: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-font-text-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+  --gcds-font-text-long: 400 1.25rem/150% "Noto Sans", sans-serif;
+  --gcds-font-text-long-mobile: 400 1rem/150% "Noto Sans", sans-serif;
   --gcds-alert-border-width: 0.375rem;
   --gcds-alert-button-border-radius: 0.375rem;
   --gcds-alert-button-border-width: 0.125rem;
@@ -226,14 +219,12 @@
   --gcds-alert-button-margin: 0 0 0 0.9375rem;
   --gcds-alert-button-mobile-margin: 0.9375rem 0 0;
   --gcds-alert-button-outline-width: 0.1875rem;
-  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975%
-      'Lato',
-    sans-serif;
+  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-alert-content-heading-margin: 0 0 0.5625rem;
   --gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
   --gcds-alert-content-slotted-list-margin: 1.5rem;
   --gcds-alert-content-slotted-margin: 0.5625rem;
-  --gcds-alert-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-alert-icon-font-size: 2.25rem;
   --gcds-alert-icon-margin: 0 0.9375rem 0 0;
   --gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -259,7 +250,7 @@
   --gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
   --gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-  --gcds-breadcrumbs-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-breadcrumbs-hover-text: #0535d2;
   --gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
   --gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -275,7 +266,7 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-button-padding: 0.75rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
@@ -295,7 +286,7 @@
   --gcds-button-shared-disabled-background: #d6d9dd;
   --gcds-button-shared-disabled-text: #545961;
   --gcds-button-skip-top: 1.5rem;
-  --gcds-button-small-font: 400 80%/120% 'Noto Sans', sans-serif;
+  --gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
   --gcds-button-small-padding: 0.75rem;
   --gcds-button-width: fit-content;
   --gcds-card-background-color: #ffffff;
@@ -316,12 +307,11 @@
   --gcds-card-margin: 0 0 1.5rem;
   --gcds-card-padding: 1.5rem;
   --gcds-card-tag-color: #43474e;
-  --gcds-card-tag-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-slot-color: #43474e;
-  --gcds-card-slot-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-title-color: #2b4380;
-  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
+  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
   --gcds-card-title-text-decoration-thickness: 0.0625rem;
   --gcds-card-title-text-underline-offset: 0.125rem;
   --gcds-checkbox-check-border-width: 0.3125rem;
@@ -339,7 +329,7 @@
   --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
-  --gcds-checkbox-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-checkbox-input-border-radius: 0.1875rem;
   --gcds-checkbox-input-border-width: 0.125rem;
   --gcds-checkbox-input-height-and-width: 3rem;
@@ -348,8 +338,7 @@
   --gcds-checkbox-max-width: 46.5rem;
   --gcds-checkbox-padding: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-  --gcds-date-modified-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-date-modified-margin: 3rem 0 1.5rem;
   --gcds-date-modified-text: #333333;
   --gcds-details-default-text: #2b4380;
@@ -360,9 +349,8 @@
   --gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-details-focus-outline-offset: 0.125rem;
   --gcds-details-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-details-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-details-font-small: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-details-hover-text: #0535d2;
   --gcds-details-hover-decoration-thickness: 0.125rem;
   --gcds-details-panel-border-color: #7d828b;
@@ -379,7 +367,7 @@
   --gcds-error-message-background: #fbddda;
   --gcds-error-message-border-color: #d3080c;
   --gcds-error-message-border-width: 0.125rem;
-  --gcds-error-message-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-error-message-margin: 0 0 1.125rem;
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-message-text: #333333;
@@ -392,9 +380,7 @@
   --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
   --gcds-error-summary-focus-link-outline-offset: 0.125rem;
   --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
+  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
   --gcds-error-summary-hover-link-thickness: 0.125rem;
   --gcds-error-summary-link-color: #a62a1e;
@@ -409,11 +395,8 @@
   --gcds-fieldset-default-text: #333333;
   --gcds-fieldset-disabled-text: #545961;
   --gcds-fieldset-focus-text: #0535d2;
-  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482%
-      'Lato',
-    sans-serif;
-  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
+  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
   --gcds-fieldset-legend-margin: 0 0 0.1875rem;
   --gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
   --gcds-file-uploader-button-background: #ffffff;
@@ -427,7 +410,7 @@
   --gcds-file-uploader-default-text: #333333;
   --gcds-file-uploader-disabled-background: #d6d9dd;
   --gcds-file-uploader-disabled-text: #545961;
-  --gcds-file-uploader-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-file-uploader-file-border-color: #7d828b;
   --gcds-file-uploader-file-border-width: 0.125rem;
   --gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -456,7 +439,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font: 400 85%/120% 'Noto Sans', sans-serif;
+  --gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -511,31 +494,18 @@
   --gcds-heading-h1-border-height: 0.375rem;
   --gcds-heading-h1-border-margin: 0.5625rem;
   --gcds-heading-h1-border-width: 4.5rem;
-  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% 'Lato',
-    sans-serif;
-  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% 'Lato', sans-serif;
+  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
   --gcds-heading-spacing-0: 0;
   --gcds-heading-spacing-50: 0.1875rem;
   --gcds-heading-spacing-100: 0.375rem;
@@ -552,9 +522,9 @@
   --gcds-heading-spacing-800: 7.5rem;
   --gcds-heading-spacing-900: 9rem;
   --gcds-heading-spacing-1000: 10.5rem;
-  --gcds-hint-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 1.125rem;
-  --gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+  --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
   --gcds-icon-font-size-caption: 1.1111111111111112rem;
   --gcds-icon-font-size-text: 1.25rem;
   --gcds-icon-font-size-h6: 1.40625rem;
@@ -604,13 +574,13 @@
   --gcds-input-disabled-text: #545961;
   --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
-  --gcds-input-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
   --gcds-input-min-width-and-height: 3rem;
   --gcds-input-outline-width: 0.1875rem;
   --gcds-input-padding: 0.75rem;
-  --gcds-label-font-desktop: 600 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-label-font-mobile: 600 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-default-text: #2b4380;
@@ -621,7 +591,7 @@
   --gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-lang-toggle-focus-outline-offset: 0.125rem;
   --gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-lang-toggle-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-lang-toggle-hover-text: #0535d2;
   --gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
   --gcds-lang-toggle-padding: 0.5625rem;
@@ -638,8 +608,7 @@
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5625rem;
   --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
-  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem
-    rgba(0, 0, 0, 0.25);
+  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.1875rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
@@ -657,8 +626,8 @@
   --gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
   --gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
   --gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-group-trigger-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-group-trigger-hover-text: #0535d2;
   --gcds-nav-group-trigger-max-width: 20rem;
   --gcds-nav-group-trigger-padding: 0.9375rem;
@@ -677,8 +646,8 @@
   --gcds-nav-link-focus-border-radius: 0.1875rem;
   --gcds-nav-link-focus-outline-offset: 0.125rem;
   --gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-link-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-link-hover-decoration-thickness: 0.125rem;
   --gcds-nav-link-hover-text: #0535d2;
   --gcds-nav-link-margin: 0.5625rem;
@@ -686,9 +655,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975%
-      'Noto Sans',
-    sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;
@@ -704,25 +671,24 @@
   --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
-  --gcds-pagination-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
   --gcds-pagination-listitem-margin: 0.375rem;
   --gcds-pagination-mobile-list-border: #2b4380;
-  --gcds-pagination-mobile-list-item-margin: 0.125rem;
+  --gcds-pagination-mobile-list-item-margin: .125rem;
   --gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
   --gcds-pagination-simple-label-font-weight: 400;
   --gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
   --gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
   --gcds-pagination-simple-padding: 0.75rem 0.5625rem;
   --gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-phase-banner-icon-margin: 1.125rem;
   --gcds-phase-banner-icon-max-height: 1.125rem;
   --gcds-phase-banner-padding: 0.9375rem;
   --gcds-phase-banner-primary-background: #26374a;
   --gcds-phase-banner-primary-text: #ffffff;
-  --gcds-phase-banner-secondary-background: #d6d9dd;
+  --gcds-phase-banner-secondary-background: #f1f2f3;
   --gcds-phase-banner-secondary-text: #333333;
   --gcds-radio-border-radius: 100%;
   --gcds-radio-check-border-width: 0.3125rem;
@@ -738,10 +704,10 @@
   --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
-  --gcds-radio-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-radio-input-border-width: 0.125rem;
   --gcds-radio-input-height-and-width: 3rem;
-  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 0 0 1.125rem;
   --gcds-radio-max-width: 46.5rem;
@@ -753,7 +719,7 @@
   --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
-  --gcds-search-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-search-margin: 0 0 0.1875rem;
   --gcds-search-min-width-and-height: 3rem;
   --gcds-search-outline-width: 0.1875rem;
@@ -768,13 +734,12 @@
   --gcds-select-disabled-text: #545961;
   --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
-  --gcds-select-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
   --gcds-select-min-width-and-height: 3rem;
   --gcds-select-outline-width: 0.1875rem;
   --gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
+  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
@@ -783,7 +748,7 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% 'Lato', sans-serif;
+  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
@@ -795,7 +760,7 @@
   --gcds-textarea-disabled-text: #545961;
   --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
-  --gcds-textarea-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;
   --gcds-textarea-min-height: 3rem;
   --gcds-textarea-outline-width: 0.1875rem;
@@ -808,7 +773,7 @@
   --gcds-topic-menu-button-expanded-background: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-border-color: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-text: #ffffff;
-  --gcds-topic-menu-button-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-button-home-background: #ffffff;
   --gcds-topic-menu-button-home-border-color: #ffffff;
   --gcds-topic-menu-button-home-text: #284162; /* Colour mandated by policy: link colour */
@@ -820,14 +785,13 @@
   --gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-topic-menu-focus-outline-offset: 0.125rem;
   --gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-topic-menu-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-max-width: 71.25rem;
   --gcds-topic-menu-menuitem-border-block-end: #545961;
   --gcds-topic-menu-menuitem-border-inline-end: #ffffff;
   --gcds-topic-menu-menuitem-expanded-background: #ffffff;
   --gcds-topic-menu-menuitem-expanded-text: #333333;
-  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
   --gcds-topic-menu-menuitem-text: #ffffff;
   --gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -846,15 +810,10 @@
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400
-      1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
-  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem
-    0.9375rem 0;
-  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
+  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
   --gcds-topic-menu-mostrequested-item-width: 100%;
   --gcds-topic-menu-themelist-background: #444; /* Colour mandated by policy */
@@ -863,11 +822,8 @@
   --gcds-topic-menu-themelist-width: 100%;
   --gcds-topic-menu-topiclist-background: #ffffff;
   --gcds-topic-menu-topiclist-border: #d6d9dd;
-  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-    rgba(0, 0, 0, 0.1);
-  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
   --gcds-topic-menu-topiclist-item-first-width: 100%;
   --gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -877,15 +833,14 @@
   --gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
   --gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
   --gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
   --gcds-topic-menu-topiclist-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-topiclist-min-height: 49.1825rem;
   --gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
   --gcds-topic-menu-topiclist-text: #000000;
   --gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-  --gcds-verify-banner-background: #d6d9dd;
+  --gcds-verify-banner-background: #f1f2f3;
   --gcds-verify-banner-container-xs: 20rem;
   --gcds-verify-banner-container-sm: 30rem;
   --gcds-verify-banner-container-md: 48rem;
@@ -900,8 +855,7 @@
   --gcds-verify-banner-content-list-svg-margin: 0.1875rem;
   --gcds-verify-banner-content-padding-block-start: 1.5rem;
   --gcds-verify-banner-content-padding-block-end: 0.75rem;
-  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-verify-banner-summary-padding: 0.75rem;
   --gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
   --gcds-verify-banner-text: #333333;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 04 Apr 2024 18:09:58 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
@@ -10,25 +10,20 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-radius: 0.1875rem;
   --gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-regular-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-link-font-regular-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
   --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-link-underline-offset: 0.25rem;
   --gcds-text-character-limit: 65ch;
   --gcds-text-role-light: #ffffff;
   --gcds-text-role-primary: #333333;
   --gcds-text-role-secondary: #43474e;
-  --gcds-text-size-body-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-text-size-body-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625%
-      'Noto Sans',
-    sans-serif;
+  --gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
   --gcds-text-spacing-0: 0;
   --gcds-text-spacing-50: 0.1875rem;
   --gcds-text-spacing-100: 0.375rem;
@@ -81,14 +76,12 @@
   --gcds-alert-button-margin: 0 0 0 0.9375rem;
   --gcds-alert-button-mobile-margin: 0.9375rem 0 0;
   --gcds-alert-button-outline-width: 0.1875rem;
-  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975%
-      'Lato',
-    sans-serif;
+  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-alert-content-heading-margin: 0 0 0.5625rem;
   --gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
   --gcds-alert-content-slotted-list-margin: 1.5rem;
   --gcds-alert-content-slotted-margin: 0.5625rem;
-  --gcds-alert-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-alert-icon-font-size: 2.25rem;
   --gcds-alert-icon-margin: 0 0.9375rem 0 0;
   --gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -114,7 +107,7 @@
   --gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
   --gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-  --gcds-breadcrumbs-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-breadcrumbs-hover-text: #0535d2;
   --gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
   --gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -130,7 +123,7 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-button-padding: 0.75rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
@@ -150,7 +143,7 @@
   --gcds-button-shared-disabled-background: #d6d9dd;
   --gcds-button-shared-disabled-text: #545961;
   --gcds-button-skip-top: 1.5rem;
-  --gcds-button-small-font: 400 80%/120% 'Noto Sans', sans-serif;
+  --gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
   --gcds-button-small-padding: 0.75rem;
   --gcds-button-width: fit-content;
   --gcds-card-background-color: #ffffff;
@@ -171,12 +164,11 @@
   --gcds-card-margin: 0 0 1.5rem;
   --gcds-card-padding: 1.5rem;
   --gcds-card-tag-color: #43474e;
-  --gcds-card-tag-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-slot-color: #43474e;
-  --gcds-card-slot-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-title-color: #2b4380;
-  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
+  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
   --gcds-card-title-text-decoration-thickness: 0.0625rem;
   --gcds-card-title-text-underline-offset: 0.125rem;
   --gcds-checkbox-check-border-width: 0.3125rem;
@@ -194,7 +186,7 @@
   --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
-  --gcds-checkbox-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-checkbox-input-border-radius: 0.1875rem;
   --gcds-checkbox-input-border-width: 0.125rem;
   --gcds-checkbox-input-height-and-width: 3rem;
@@ -203,8 +195,7 @@
   --gcds-checkbox-max-width: 46.5rem;
   --gcds-checkbox-padding: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-  --gcds-date-modified-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-date-modified-margin: 3rem 0 1.5rem;
   --gcds-date-modified-text: #333333;
   --gcds-details-default-text: #2b4380;
@@ -215,9 +206,8 @@
   --gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-details-focus-outline-offset: 0.125rem;
   --gcds-details-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-details-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-details-font-small: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-details-hover-text: #0535d2;
   --gcds-details-hover-decoration-thickness: 0.125rem;
   --gcds-details-panel-border-color: #7d828b;
@@ -234,7 +224,7 @@
   --gcds-error-message-background: #fbddda;
   --gcds-error-message-border-color: #d3080c;
   --gcds-error-message-border-width: 0.125rem;
-  --gcds-error-message-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-error-message-margin: 0 0 1.125rem;
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-message-text: #333333;
@@ -247,9 +237,7 @@
   --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
   --gcds-error-summary-focus-link-outline-offset: 0.125rem;
   --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
+  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
   --gcds-error-summary-hover-link-thickness: 0.125rem;
   --gcds-error-summary-link-color: #a62a1e;
@@ -264,11 +252,8 @@
   --gcds-fieldset-default-text: #333333;
   --gcds-fieldset-disabled-text: #545961;
   --gcds-fieldset-focus-text: #0535d2;
-  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482%
-      'Lato',
-    sans-serif;
-  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
+  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
   --gcds-fieldset-legend-margin: 0 0 0.1875rem;
   --gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
   --gcds-file-uploader-button-background: #ffffff;
@@ -282,7 +267,7 @@
   --gcds-file-uploader-default-text: #333333;
   --gcds-file-uploader-disabled-background: #d6d9dd;
   --gcds-file-uploader-disabled-text: #545961;
-  --gcds-file-uploader-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-file-uploader-file-border-color: #7d828b;
   --gcds-file-uploader-file-border-width: 0.125rem;
   --gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -311,7 +296,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font: 400 85%/120% 'Noto Sans', sans-serif;
+  --gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -366,31 +351,18 @@
   --gcds-heading-h1-border-height: 0.375rem;
   --gcds-heading-h1-border-margin: 0.5625rem;
   --gcds-heading-h1-border-width: 4.5rem;
-  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% 'Lato',
-    sans-serif;
-  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% 'Lato', sans-serif;
+  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
   --gcds-heading-spacing-0: 0;
   --gcds-heading-spacing-50: 0.1875rem;
   --gcds-heading-spacing-100: 0.375rem;
@@ -407,9 +379,9 @@
   --gcds-heading-spacing-800: 7.5rem;
   --gcds-heading-spacing-900: 9rem;
   --gcds-heading-spacing-1000: 10.5rem;
-  --gcds-hint-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 1.125rem;
-  --gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+  --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
   --gcds-icon-font-size-caption: 1.1111111111111112rem;
   --gcds-icon-font-size-text: 1.25rem;
   --gcds-icon-font-size-h6: 1.40625rem;
@@ -459,13 +431,13 @@
   --gcds-input-disabled-text: #545961;
   --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
-  --gcds-input-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
   --gcds-input-min-width-and-height: 3rem;
   --gcds-input-outline-width: 0.1875rem;
   --gcds-input-padding: 0.75rem;
-  --gcds-label-font-desktop: 600 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-label-font-mobile: 600 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-default-text: #2b4380;
@@ -476,7 +448,7 @@
   --gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-lang-toggle-focus-outline-offset: 0.125rem;
   --gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-lang-toggle-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-lang-toggle-hover-text: #0535d2;
   --gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
   --gcds-lang-toggle-padding: 0.5625rem;
@@ -493,8 +465,7 @@
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5625rem;
   --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
-  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem
-    rgba(0, 0, 0, 0.25);
+  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.1875rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
@@ -512,8 +483,8 @@
   --gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
   --gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
   --gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-group-trigger-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-group-trigger-hover-text: #0535d2;
   --gcds-nav-group-trigger-max-width: 20rem;
   --gcds-nav-group-trigger-padding: 0.9375rem;
@@ -532,8 +503,8 @@
   --gcds-nav-link-focus-border-radius: 0.1875rem;
   --gcds-nav-link-focus-outline-offset: 0.125rem;
   --gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-link-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-link-hover-decoration-thickness: 0.125rem;
   --gcds-nav-link-hover-text: #0535d2;
   --gcds-nav-link-margin: 0.5625rem;
@@ -541,9 +512,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975%
-      'Noto Sans',
-    sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;
@@ -559,25 +528,24 @@
   --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
-  --gcds-pagination-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
   --gcds-pagination-listitem-margin: 0.375rem;
   --gcds-pagination-mobile-list-border: #2b4380;
-  --gcds-pagination-mobile-list-item-margin: 0.125rem;
+  --gcds-pagination-mobile-list-item-margin: .125rem;
   --gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
   --gcds-pagination-simple-label-font-weight: 400;
   --gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
   --gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
   --gcds-pagination-simple-padding: 0.75rem 0.5625rem;
   --gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-phase-banner-icon-margin: 1.125rem;
   --gcds-phase-banner-icon-max-height: 1.125rem;
   --gcds-phase-banner-padding: 0.9375rem;
   --gcds-phase-banner-primary-background: #26374a;
   --gcds-phase-banner-primary-text: #ffffff;
-  --gcds-phase-banner-secondary-background: #d6d9dd;
+  --gcds-phase-banner-secondary-background: #f1f2f3;
   --gcds-phase-banner-secondary-text: #333333;
   --gcds-radio-border-radius: 100%;
   --gcds-radio-check-border-width: 0.3125rem;
@@ -593,10 +561,10 @@
   --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
-  --gcds-radio-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-radio-input-border-width: 0.125rem;
   --gcds-radio-input-height-and-width: 3rem;
-  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 0 0 1.125rem;
   --gcds-radio-max-width: 46.5rem;
@@ -608,7 +576,7 @@
   --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
-  --gcds-search-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-search-margin: 0 0 0.1875rem;
   --gcds-search-min-width-and-height: 3rem;
   --gcds-search-outline-width: 0.1875rem;
@@ -623,13 +591,12 @@
   --gcds-select-disabled-text: #545961;
   --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
-  --gcds-select-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
   --gcds-select-min-width-and-height: 3rem;
   --gcds-select-outline-width: 0.1875rem;
   --gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
+  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
@@ -638,7 +605,7 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% 'Lato', sans-serif;
+  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
@@ -650,7 +617,7 @@
   --gcds-textarea-disabled-text: #545961;
   --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
-  --gcds-textarea-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;
   --gcds-textarea-min-height: 3rem;
   --gcds-textarea-outline-width: 0.1875rem;
@@ -663,7 +630,7 @@
   --gcds-topic-menu-button-expanded-background: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-border-color: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-text: #ffffff;
-  --gcds-topic-menu-button-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-button-home-background: #ffffff;
   --gcds-topic-menu-button-home-border-color: #ffffff;
   --gcds-topic-menu-button-home-text: #284162; /* Colour mandated by policy: link colour */
@@ -675,14 +642,13 @@
   --gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-topic-menu-focus-outline-offset: 0.125rem;
   --gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-topic-menu-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-max-width: 71.25rem;
   --gcds-topic-menu-menuitem-border-block-end: #545961;
   --gcds-topic-menu-menuitem-border-inline-end: #ffffff;
   --gcds-topic-menu-menuitem-expanded-background: #ffffff;
   --gcds-topic-menu-menuitem-expanded-text: #333333;
-  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
   --gcds-topic-menu-menuitem-text: #ffffff;
   --gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -701,15 +667,10 @@
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400
-      1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
-  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem
-    0.9375rem 0;
-  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
+  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
   --gcds-topic-menu-mostrequested-item-width: 100%;
   --gcds-topic-menu-themelist-background: #444; /* Colour mandated by policy */
@@ -718,11 +679,8 @@
   --gcds-topic-menu-themelist-width: 100%;
   --gcds-topic-menu-topiclist-background: #ffffff;
   --gcds-topic-menu-topiclist-border: #d6d9dd;
-  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-    rgba(0, 0, 0, 0.1);
-  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
   --gcds-topic-menu-topiclist-item-first-width: 100%;
   --gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -732,15 +690,14 @@
   --gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
   --gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
   --gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
   --gcds-topic-menu-topiclist-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-topiclist-min-height: 49.1825rem;
   --gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
   --gcds-topic-menu-topiclist-text: #000000;
   --gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-  --gcds-verify-banner-background: #d6d9dd;
+  --gcds-verify-banner-background: #f1f2f3;
   --gcds-verify-banner-container-xs: 20rem;
   --gcds-verify-banner-container-sm: 30rem;
   --gcds-verify-banner-container-md: 48rem;
@@ -755,8 +712,7 @@
   --gcds-verify-banner-content-list-svg-margin: 0.1875rem;
   --gcds-verify-banner-content-padding-block-start: 1.5rem;
   --gcds-verify-banner-content-padding-block-end: 0.75rem;
-  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-verify-banner-summary-padding: 0.75rem;
   --gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
   --gcds-verify-banner-text: #333333;

--- a/build/web/css/components/phase-banner.css
+++ b/build/web/css/components/phase-banner.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 22 Jun 2023 14:47:37 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
@@ -11,6 +11,6 @@
   --gcds-phase-banner-padding: 0.9375rem;
   --gcds-phase-banner-primary-background: #26374a;
   --gcds-phase-banner-primary-text: #ffffff;
-  --gcds-phase-banner-secondary-background: #d6d9dd;
+  --gcds-phase-banner-secondary-background: #f1f2f3;
   --gcds-phase-banner-secondary-text: #333333;
 }

--- a/build/web/css/components/verify-banner.css
+++ b/build/web/css/components/verify-banner.css
@@ -1,10 +1,10 @@
 /**
  * Do not edit directly
- * Generated on Tue, 27 Jun 2023 23:49:41 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
-  --gcds-verify-banner-background: #d6d9dd;
+  --gcds-verify-banner-background: #f1f2f3;
   --gcds-verify-banner-container-xs: 20rem;
   --gcds-verify-banner-container-sm: 30rem;
   --gcds-verify-banner-container-md: 48rem;

--- a/build/web/css/global.css
+++ b/build/web/css/global.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 05 Oct 2023 20:50:40 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
@@ -15,6 +15,11 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
+  --gcds-bg-black: #000000; /* Global bg color: black background */
+  --gcds-bg-dark: #333333; /* Global bg color: dark background */
+  --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
+  --gcds-bg-primary: #26374a; /* Global bg color: primary background */
+  --gcds-bg-white: #ffffff; /* Global bg color: white background */
   --gcds-danger-background: #fbddda; /* Global color: danger background */
   --gcds-danger-border: #d3080c; /* Global color: danger border */
   --gcds-danger-text: #a62a1e; /* Global color: danger text */

--- a/build/web/css/global/color.css
+++ b/build/web/css/global/color.css
@@ -1,12 +1,17 @@
 /**
  * Do not edit directly
- * Generated on Mon, 19 Jun 2023 20:28:18 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
+  --gcds-bg-black: #000000; /* Global bg color: black background */
+  --gcds-bg-dark: #333333; /* Global bg color: dark background */
+  --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
+  --gcds-bg-primary: #26374a; /* Global bg color: primary background */
+  --gcds-bg-white: #ffffff; /* Global bg color: white background */
   --gcds-danger-background: #fbddda; /* Global color: danger background */
   --gcds-danger-border: #d3080c; /* Global color: danger border */
   --gcds-danger-text: #a62a1e; /* Global color: danger text */

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 04 Apr 2024 18:09:58 GMT
+ * Generated on Mon, 15 Apr 2024 23:56:04 GMT
  */
 
 :root {
@@ -40,6 +40,11 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
+  --gcds-bg-black: #000000; /* Global bg color: black background */
+  --gcds-bg-dark: #333333; /* Global bg color: dark background */
+  --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
+  --gcds-bg-primary: #26374a; /* Global bg color: primary background */
+  --gcds-bg-white: #ffffff; /* Global bg color: white background */
   --gcds-danger-background: #fbddda; /* Global color: danger background */
   --gcds-danger-border: #d3080c; /* Global color: danger border */
   --gcds-danger-text: #a62a1e; /* Global color: danger text */
@@ -57,12 +62,10 @@
   --gcds-link-focus-text: #ffffff;
   --gcds-link-focus-border-radius: 0.1875rem;
   --gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% 'Noto Sans',
-    sans-serif;
-  --gcds-link-font-regular-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-link-font-regular-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
   --gcds-link-decoration-thickness: 0.0625rem;
   --gcds-link-underline-offset: 0.25rem;
   --gcds-text-light: #ffffff; /* Global color: text light */
@@ -72,13 +75,10 @@
   --gcds-text-role-light: #ffffff;
   --gcds-text-role-primary: #333333;
   --gcds-text-role-secondary: #43474e;
-  --gcds-text-size-body-desktop: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-text-size-body-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
-  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625%
-      'Noto Sans',
-    sans-serif;
+  --gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
   --gcds-text-spacing-0: 0;
   --gcds-text-spacing-50: 0.1875rem;
   --gcds-text-spacing-100: 0.375rem;
@@ -146,10 +146,10 @@
   --gcds-base-font-size-mobile: 1; /* Sets base font size for smaller screens to 16px */
   --gcds-base-line-height: 1.2; /* Sets base line height to 24px */
   --gcds-base-scale: 1.125;
-  --gcds-font-families-heading: 'Lato', sans-serif;
-  --gcds-font-families-body: 'Noto Sans', sans-serif;
-  --gcds-font-families-monospace: 'Menlo', sans-serif;
-  --gcds-font-families-icons: 'Font Awesome 6 Free', FontAwesome;
+  --gcds-font-families-heading: "Lato", sans-serif;
+  --gcds-font-families-body: "Noto Sans", sans-serif;
+  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;
   --gcds-font-sizes-text: 1.25rem;
@@ -187,33 +187,26 @@
   --gcds-line-heights-h2-mobile: 124.85901539399481%;
   --gcds-line-heights-h1: 118.38484422541731%;
   --gcds-line-heights-h1-mobile: 123.31754606814303%;
-  --gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% 'Lato',
-    sans-serif;
-  --gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% 'Lato',
-    sans-serif;
-  --gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% 'Lato',
-    sans-serif;
-  --gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% 'Lato', sans-serif;
-  --gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-font-h4: 700 1.77978515625rem/126.41975308641973% 'Lato', sans-serif;
-  --gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% 'Lato',
-    sans-serif;
-  --gcds-font-h5: 700 1.58203125rem/126.41975308641975% 'Lato', sans-serif;
-  --gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% 'Lato', sans-serif;
-  --gcds-font-h6: 700 1.40625rem/124.44444444444444% 'Lato', sans-serif;
-  --gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-caption: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
-  --gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% 'Noto Sans',
-    sans-serif;
-  --gcds-font-text: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-font-text-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-text-long: 400 1.25rem/150% 'Noto Sans', sans-serif;
-  --gcds-font-text-long-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+  --gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+  --gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+  --gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-font-h4: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+  --gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+  --gcds-font-h5: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+  --gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+  --gcds-font-h6: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+  --gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
+  --gcds-font-label: 500 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-font-label-mobile: 500 1rem/150% "Noto Sans", sans-serif;
+  --gcds-font-caption: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+  --gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+  --gcds-font-text: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-font-text-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+  --gcds-font-text-long: 400 1.25rem/150% "Noto Sans", sans-serif;
+  --gcds-font-text-long-mobile: 400 1rem/150% "Noto Sans", sans-serif;
   --gcds-alert-border-width: 0.375rem;
   --gcds-alert-button-border-radius: 0.375rem;
   --gcds-alert-button-border-width: 0.125rem;
@@ -226,14 +219,12 @@
   --gcds-alert-button-margin: 0 0 0 0.9375rem;
   --gcds-alert-button-mobile-margin: 0.9375rem 0 0;
   --gcds-alert-button-outline-width: 0.1875rem;
-  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975%
-      'Lato',
-    sans-serif;
+  --gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-alert-content-heading-margin: 0 0 0.5625rem;
   --gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
   --gcds-alert-content-slotted-list-margin: 1.5rem;
   --gcds-alert-content-slotted-margin: 0.5625rem;
-  --gcds-alert-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-alert-icon-font-size: 2.25rem;
   --gcds-alert-icon-margin: 0 0.9375rem 0 0;
   --gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -259,7 +250,7 @@
   --gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
   --gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-  --gcds-breadcrumbs-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-breadcrumbs-hover-text: #0535d2;
   --gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
   --gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -275,7 +266,7 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-button-padding: 0.75rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
@@ -295,7 +286,7 @@
   --gcds-button-shared-disabled-background: #d6d9dd;
   --gcds-button-shared-disabled-text: #545961;
   --gcds-button-skip-top: 1.5rem;
-  --gcds-button-small-font: 400 80%/120% 'Noto Sans', sans-serif;
+  --gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
   --gcds-button-small-padding: 0.75rem;
   --gcds-button-width: fit-content;
   --gcds-card-background-color: #ffffff;
@@ -316,12 +307,11 @@
   --gcds-card-margin: 0 0 1.5rem;
   --gcds-card-padding: 1.5rem;
   --gcds-card-tag-color: #43474e;
-  --gcds-card-tag-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-slot-color: #43474e;
-  --gcds-card-slot-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-card-title-color: #2b4380;
-  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
+  --gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
   --gcds-card-title-text-decoration-thickness: 0.0625rem;
   --gcds-card-title-text-underline-offset: 0.125rem;
   --gcds-checkbox-check-border-width: 0.3125rem;
@@ -339,7 +329,7 @@
   --gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-checkbox-focus-text: #0535d2;
   --gcds-checkbox-focus-outline-width: 0.1875rem;
-  --gcds-checkbox-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-checkbox-input-border-radius: 0.1875rem;
   --gcds-checkbox-input-border-width: 0.125rem;
   --gcds-checkbox-input-height-and-width: 3rem;
@@ -348,8 +338,7 @@
   --gcds-checkbox-max-width: 46.5rem;
   --gcds-checkbox-padding: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-  --gcds-date-modified-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-date-modified-margin: 3rem 0 1.5rem;
   --gcds-date-modified-text: #333333;
   --gcds-details-default-text: #2b4380;
@@ -360,9 +349,8 @@
   --gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-details-focus-outline-offset: 0.125rem;
   --gcds-details-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-details-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-details-font-small: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-details-hover-text: #0535d2;
   --gcds-details-hover-decoration-thickness: 0.125rem;
   --gcds-details-panel-border-color: #7d828b;
@@ -379,7 +367,7 @@
   --gcds-error-message-background: #fbddda;
   --gcds-error-message-border-color: #d3080c;
   --gcds-error-message-border-width: 0.125rem;
-  --gcds-error-message-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-error-message-margin: 0 0 1.125rem;
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-message-text: #333333;
@@ -392,9 +380,7 @@
   --gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
   --gcds-error-summary-focus-link-outline-offset: 0.125rem;
   --gcds-error-summary-focus-link-text: #ffffff;
-  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
+  --gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
   --gcds-error-summary-heading-padding-bottom: 1.125rem;
   --gcds-error-summary-hover-link-thickness: 0.125rem;
   --gcds-error-summary-link-color: #a62a1e;
@@ -409,11 +395,8 @@
   --gcds-fieldset-default-text: #333333;
   --gcds-fieldset-disabled-text: #545961;
   --gcds-fieldset-focus-text: #0535d2;
-  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482%
-      'Lato',
-    sans-serif;
-  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
+  --gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
   --gcds-fieldset-legend-margin: 0 0 0.1875rem;
   --gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
   --gcds-file-uploader-button-background: #ffffff;
@@ -427,7 +410,7 @@
   --gcds-file-uploader-default-text: #333333;
   --gcds-file-uploader-disabled-background: #d6d9dd;
   --gcds-file-uploader-disabled-text: #545961;
-  --gcds-file-uploader-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-file-uploader-file-border-color: #7d828b;
   --gcds-file-uploader-file-border-width: 0.125rem;
   --gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -456,7 +439,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font: 400 85%/120% 'Noto Sans', sans-serif;
+  --gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -511,31 +494,18 @@
   --gcds-heading-h1-border-height: 0.375rem;
   --gcds-heading-h1-border-margin: 0.5625rem;
   --gcds-heading-h1-border-width: 4.5rem;
-  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% 'Lato',
-    sans-serif;
-  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162%
-      'Lato',
-    sans-serif;
-  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% 'Lato',
-    sans-serif;
-  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% 'Lato',
-    sans-serif;
-  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
-  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% 'Lato',
-    sans-serif;
-  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% 'Lato', sans-serif;
+  --gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+  --gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+  --gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+  --gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+  --gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+  --gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+  --gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+  --gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+  --gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+  --gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+  --gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
   --gcds-heading-spacing-0: 0;
   --gcds-heading-spacing-50: 0.1875rem;
   --gcds-heading-spacing-100: 0.375rem;
@@ -552,9 +522,9 @@
   --gcds-heading-spacing-800: 7.5rem;
   --gcds-heading-spacing-900: 9rem;
   --gcds-heading-spacing-1000: 10.5rem;
-  --gcds-hint-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-hint-margin: 0 0 1.125rem;
-  --gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+  --gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
   --gcds-icon-font-size-caption: 1.1111111111111112rem;
   --gcds-icon-font-size-text: 1.25rem;
   --gcds-icon-font-size-h6: 1.40625rem;
@@ -604,13 +574,13 @@
   --gcds-input-disabled-text: #545961;
   --gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-input-focus-text: #0535d2;
-  --gcds-input-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-input-margin: 0 0 1.5rem;
   --gcds-input-min-width-and-height: 3rem;
   --gcds-input-outline-width: 0.1875rem;
   --gcds-input-padding: 0.75rem;
-  --gcds-label-font-desktop: 600 1.25rem/120% 'Noto Sans', sans-serif;
-  --gcds-label-font-mobile: 600 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+  --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-default-text: #2b4380;
@@ -621,7 +591,7 @@
   --gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-lang-toggle-focus-outline-offset: 0.125rem;
   --gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-lang-toggle-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-lang-toggle-hover-text: #0535d2;
   --gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
   --gcds-lang-toggle-padding: 0.5625rem;
@@ -638,8 +608,7 @@
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5625rem;
   --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
-  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem
-    rgba(0, 0, 0, 0.25);
+  --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5625rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.1875rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
@@ -657,8 +626,8 @@
   --gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
   --gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
   --gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-group-trigger-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-group-trigger-hover-text: #0535d2;
   --gcds-nav-group-trigger-max-width: 20rem;
   --gcds-nav-group-trigger-padding: 0.9375rem;
@@ -677,8 +646,8 @@
   --gcds-nav-link-focus-border-radius: 0.1875rem;
   --gcds-nav-link-focus-outline-offset: 0.125rem;
   --gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-  --gcds-nav-link-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+  --gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-nav-link-hover-decoration-thickness: 0.125rem;
   --gcds-nav-link-hover-text: #0535d2;
   --gcds-nav-link-margin: 0.5625rem;
@@ -686,9 +655,7 @@
   --gcds-nav-link-side-nav-hover-background: #f1f2f3;
   --gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
   --gcds-nav-link-top-nav-hover-background: #d6d9dd;
-  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975%
-      'Noto Sans',
-    sans-serif;
+  --gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
   --gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
   --gcds-nav-link-top-nav-padding: 1.125rem;
   --gcds-nav-link-top-nav-text: #333333;
@@ -704,25 +671,24 @@
   --gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-pagination-focus-text: #ffffff;
   --gcds-pagination-focus-outline-width: 0.1875rem;
-  --gcds-pagination-font: 500 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
   --gcds-pagination-listitem-margin: 0.375rem;
   --gcds-pagination-mobile-list-border: #2b4380;
-  --gcds-pagination-mobile-list-item-margin: 0.125rem;
+  --gcds-pagination-mobile-list-item-margin: .125rem;
   --gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
   --gcds-pagination-simple-label-font-weight: 400;
   --gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
   --gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
   --gcds-pagination-simple-padding: 0.75rem 0.5625rem;
   --gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-phase-banner-icon-margin: 1.125rem;
   --gcds-phase-banner-icon-max-height: 1.125rem;
   --gcds-phase-banner-padding: 0.9375rem;
   --gcds-phase-banner-primary-background: #26374a;
   --gcds-phase-banner-primary-text: #ffffff;
-  --gcds-phase-banner-secondary-background: #d6d9dd;
+  --gcds-phase-banner-secondary-background: #f1f2f3;
   --gcds-phase-banner-secondary-text: #333333;
   --gcds-radio-border-radius: 100%;
   --gcds-radio-check-border-width: 0.3125rem;
@@ -738,10 +704,10 @@
   --gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-radio-focus-text: #0535d2;
   --gcds-radio-focus-outline-width: 0.1875rem;
-  --gcds-radio-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-radio-input-border-width: 0.125rem;
   --gcds-radio-input-height-and-width: 3rem;
-  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% 'Noto Sans', sans-serif;
+  --gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-radio-label-padding: 0 0 0 3.75rem;
   --gcds-radio-margin: 0 0 1.125rem;
   --gcds-radio-max-width: 46.5rem;
@@ -753,7 +719,7 @@
   --gcds-search-focus-border-radius: 0.1875rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-focus-text: #0535d2;
-  --gcds-search-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-search-margin: 0 0 0.1875rem;
   --gcds-search-min-width-and-height: 3rem;
   --gcds-search-outline-width: 0.1875rem;
@@ -768,13 +734,12 @@
   --gcds-select-disabled-text: #545961;
   --gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-select-focus-text: #0535d2;
-  --gcds-select-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-select-margin: 0 0 1.5rem;
   --gcds-select-min-width-and-height: 3rem;
   --gcds-select-outline-width: 0.1875rem;
   --gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% 'Lato',
-    sans-serif;
+  --gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
@@ -783,7 +748,7 @@
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;
   --gcds-signature-wordmark-height: 3rem;
-  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% 'Lato', sans-serif;
+  --gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
   --gcds-stepper-margin: 0 0 1.125rem;
   --gcds-stepper-text: #43474e;
   --gcds-textarea-border-radius: 0.1875rem;
@@ -795,7 +760,7 @@
   --gcds-textarea-disabled-text: #545961;
   --gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-textarea-focus-text: #0535d2;
-  --gcds-textarea-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-textarea-margin: 0 0 1.5rem;
   --gcds-textarea-min-height: 3rem;
   --gcds-textarea-outline-width: 0.1875rem;
@@ -808,7 +773,7 @@
   --gcds-topic-menu-button-expanded-background: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-border-color: #444; /* Colour mandated by policy */
   --gcds-topic-menu-button-expanded-text: #ffffff;
-  --gcds-topic-menu-button-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-button-home-background: #ffffff;
   --gcds-topic-menu-button-home-border-color: #ffffff;
   --gcds-topic-menu-button-home-text: #284162; /* Colour mandated by policy: link colour */
@@ -820,14 +785,13 @@
   --gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-topic-menu-focus-outline-offset: 0.125rem;
   --gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-  --gcds-topic-menu-font: 400 1.25rem/120% 'Noto Sans', sans-serif;
+  --gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-max-width: 71.25rem;
   --gcds-topic-menu-menuitem-border-block-end: #545961;
   --gcds-topic-menu-menuitem-border-inline-end: #ffffff;
   --gcds-topic-menu-menuitem-expanded-background: #ffffff;
   --gcds-topic-menu-menuitem-expanded-text: #333333;
-  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
   --gcds-topic-menu-menuitem-text: #ffffff;
   --gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -846,15 +810,10 @@
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
   --gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400
-      1.1111111111111112rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
-  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem
-    0.9375rem 0;
-  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
+  --gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
   --gcds-topic-menu-mostrequested-item-width: 100%;
   --gcds-topic-menu-themelist-background: #444; /* Colour mandated by policy */
@@ -863,11 +822,8 @@
   --gcds-topic-menu-themelist-width: 100%;
   --gcds-topic-menu-topiclist-background: #ffffff;
   --gcds-topic-menu-topiclist-border: #d6d9dd;
-  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-    rgba(0, 0, 0, 0.1);
-  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482%
-      'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+  --gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
   --gcds-topic-menu-topiclist-item-first-width: 100%;
   --gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -877,15 +833,14 @@
   --gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
   --gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
   --gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% 'Noto Sans',
-    sans-serif;
+  --gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
   --gcds-topic-menu-topiclist-menuitem-text: #284162; /* Colour mandated by policy: link colour */
   --gcds-topic-menu-topiclist-min-height: 49.1825rem;
   --gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
   --gcds-topic-menu-topiclist-text: #000000;
   --gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-  --gcds-verify-banner-background: #d6d9dd;
+  --gcds-verify-banner-background: #f1f2f3;
   --gcds-verify-banner-container-xs: 20rem;
   --gcds-verify-banner-container-sm: 30rem;
   --gcds-verify-banner-container-md: 48rem;
@@ -900,8 +855,7 @@
   --gcds-verify-banner-content-list-svg-margin: 0.1875rem;
   --gcds-verify-banner-content-padding-block-start: 1.5rem;
   --gcds-verify-banner-content-padding-block-end: 0.75rem;
-  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% 'Noto Sans',
-    sans-serif;
+  --gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
   --gcds-verify-banner-summary-padding: 0.75rem;
   --gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
   --gcds-verify-banner-text: #333333;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,5 +1,6 @@
+
 // Do not edit directly
-// Generated on Thu, 04 Apr 2024 18:09:58 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -37,6 +38,11 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
+$gcds-bg-black: #000000; // Global bg color: black background
+$gcds-bg-dark: #333333; // Global bg color: dark background
+$gcds-bg-light: #f1f2f3; // Global bg color: light background
+$gcds-bg-primary: #26374a; // Global bg color: primary background
+$gcds-bg-white: #ffffff; // Global bg color: white background
 $gcds-danger-background: #fbddda; // Global color: danger background
 $gcds-danger-border: #d3080c; // Global color: danger border
 $gcds-danger-text: #a62a1e; // Global color: danger text
@@ -54,18 +60,10 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-radius: 0.1875rem;
 $gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-link-font-small-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-small-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+$gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
 $gcds-link-decoration-thickness: 0.0625rem;
 $gcds-link-underline-offset: 0.25rem;
 $gcds-text-light: #ffffff; // Global color: text light
@@ -75,18 +73,10 @@ $gcds-text-character-limit: 65ch;
 $gcds-text-role-light: #ffffff;
 $gcds-text-role-primary: #333333;
 $gcds-text-role-secondary: #43474e;
-$gcds-text-size-body-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-body-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
+$gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+$gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
 $gcds-text-spacing-0: 0;
 $gcds-text-spacing-50: 0.1875rem;
 $gcds-text-spacing-100: 0.375rem;
@@ -154,10 +144,10 @@ $gcds-base-font-size: 1.25; // Sets base font size to 20px
 $gcds-base-font-size-mobile: 1; // Sets base font size for smaller screens to 16px
 $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
-$gcds-font-families-heading: 'Lato', sans-serif;
-$gcds-font-families-body: 'Noto Sans', sans-serif;
-$gcds-font-families-monospace: 'Menlo', sans-serif;
-$gcds-font-families-icons: 'Font Awesome 6 Free', FontAwesome;
+$gcds-font-families-heading: "Lato", sans-serif;
+$gcds-font-families-body: "Noto Sans", sans-serif;
+$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;
 $gcds-font-sizes-text: 1.25rem;
@@ -195,66 +185,26 @@ $gcds-line-heights-h2: 122.08437060746162%;
 $gcds-line-heights-h2-mobile: 124.85901539399481%;
 $gcds-line-heights-h1: 118.38484422541731%;
 $gcds-line-heights-h1-mobile: 123.31754606814303%;
-$gcds-font-h1:
-  700 2.5341081619262695rem/118.38484422541731% 'Lato',
-  sans-serif;
-$gcds-font-h1-mobile:
-  700 2.0272865295410156rem/123.31754606814303% 'Lato',
-  sans-serif;
-$gcds-font-h2:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
-$gcds-font-h2-mobile:
-  700 1.802032470703125rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-font-h3:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-font-h3-mobile:
-  700 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-font-h4:
-  700 1.77978515625rem/126.41975308641973% 'Lato',
-  sans-serif;
-$gcds-font-h4-mobile:
-  700 1.423828125rem/122.90809327846364% 'Lato',
-  sans-serif;
-$gcds-font-h5:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
-$gcds-font-h5-mobile:
-  700 1.265625rem/138.27160493827162% 'Lato',
-  sans-serif;
-$gcds-font-h6:
-  700 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
-$gcds-font-h6-mobile:
-  700 1.125rem/133.33333333333334% 'Lato',
-  sans-serif;
-$gcds-font-label:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-font-label-mobile:
-  500 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-caption:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-font-caption-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
-$gcds-font-text:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-long:
-  400 1.25rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-long-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+$gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+$gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+$gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+$gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+$gcds-font-h4: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+$gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+$gcds-font-h5: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+$gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+$gcds-font-h6: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+$gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
+$gcds-font-label: 500 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-font-label-mobile: 500 1rem/150% "Noto Sans", sans-serif;
+$gcds-font-caption: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+$gcds-font-text: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-font-text-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+$gcds-font-text-long: 400 1.25rem/150% "Noto Sans", sans-serif;
+$gcds-font-text-long-mobile: 400 1rem/150% "Noto Sans", sans-serif;
 $gcds-alert-border-width: 0.375rem;
 $gcds-alert-button-border-radius: 0.375rem;
 $gcds-alert-button-border-width: 0.125rem;
@@ -267,16 +217,12 @@ $gcds-alert-button-icon-width-and-height: 1.125rem;
 $gcds-alert-button-margin: 0 0 0 0.9375rem;
 $gcds-alert-button-mobile-margin: 0.9375rem 0 0;
 $gcds-alert-button-outline-width: 0.1875rem;
-$gcds-alert-content-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-alert-content-heading-margin: 0 0 0.5625rem;
 $gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
 $gcds-alert-content-slotted-list-margin: 1.5rem;
 $gcds-alert-content-slotted-margin: 0.5625rem;
-$gcds-alert-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-alert-icon-font-size: 2.25rem;
 $gcds-alert-icon-margin: 0 0.9375rem 0 0;
 $gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -302,9 +248,7 @@ $gcds-breadcrumbs-focus-text: #ffffff;
 $gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
 $gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-$gcds-breadcrumbs-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-breadcrumbs-hover-text: #0535d2;
 $gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
 $gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -320,9 +264,7 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-button-padding: 0.75rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
@@ -342,9 +284,7 @@ $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
 $gcds-button-shared-disabled-text: #545961;
 $gcds-button-skip-top: 1.5rem;
-$gcds-button-small-font:
-  400 80%/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
 $gcds-button-small-padding: 0.75rem;
 $gcds-button-width: fit-content;
 $gcds-card-background-color: #ffffff;
@@ -365,17 +305,11 @@ $gcds-card-hover-title-text-decoration-thickness: 0.125rem;
 $gcds-card-margin: 0 0 1.5rem;
 $gcds-card-padding: 1.5rem;
 $gcds-card-tag-color: #43474e;
-$gcds-card-tag-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-slot-color: #43474e;
-$gcds-card-slot-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-title-color: #2b4380;
-$gcds-card-title-font:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
+$gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
 $gcds-card-title-text-decoration-thickness: 0.0625rem;
 $gcds-card-title-text-underline-offset: 0.125rem;
 $gcds-checkbox-check-border-width: 0.3125rem;
@@ -393,9 +327,7 @@ $gcds-checkbox-focus-background: #ffffff;
 $gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
-$gcds-checkbox-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-checkbox-input-border-radius: 0.1875rem;
 $gcds-checkbox-input-border-width: 0.125rem;
 $gcds-checkbox-input-height-and-width: 3rem;
@@ -404,9 +336,7 @@ $gcds-checkbox-margin: 0 0 1.125rem;
 $gcds-checkbox-max-width: 46.5rem;
 $gcds-checkbox-padding: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-$gcds-date-modified-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-date-modified-margin: 3rem 0 1.5rem;
 $gcds-date-modified-text: #333333;
 $gcds-details-default-text: #2b4380;
@@ -417,12 +347,8 @@ $gcds-details-focus-border-radius: 0.1875rem;
 $gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-details-focus-outline-offset: 0.125rem;
 $gcds-details-focus-outline: 0.1875rem solid #0535d2;
-$gcds-details-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-details-font-small:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-details-hover-text: #0535d2;
 $gcds-details-hover-decoration-thickness: 0.125rem;
 $gcds-details-panel-border-color: #7d828b;
@@ -439,9 +365,7 @@ $gcds-details-summary-padding: 0.375rem 0.375rem 0.375rem 2.25rem;
 $gcds-error-message-background: #fbddda;
 $gcds-error-message-border-color: #d3080c;
 $gcds-error-message-border-width: 0.125rem;
-$gcds-error-message-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-message-text: #333333;
@@ -454,9 +378,7 @@ $gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
 $gcds-error-summary-focus-link-outline-offset: 0.125rem;
 $gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
+$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
 $gcds-error-summary-hover-link-thickness: 0.125rem;
 $gcds-error-summary-link-color: #a62a1e;
@@ -471,12 +393,8 @@ $gcds-error-summary-padding: 2.25rem;
 $gcds-fieldset-default-text: #333333;
 $gcds-fieldset-disabled-text: #545961;
 $gcds-fieldset-focus-text: #0535d2;
-$gcds-fieldset-font-desktop:
-  600 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-fieldset-font-mobile:
-  600 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
+$gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
 $gcds-fieldset-legend-margin: 0 0 0.1875rem;
 $gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
 $gcds-file-uploader-button-background: #ffffff;
@@ -490,9 +408,7 @@ $gcds-file-uploader-button-text: #2b4380;
 $gcds-file-uploader-default-text: #333333;
 $gcds-file-uploader-disabled-background: #d6d9dd;
 $gcds-file-uploader-disabled-text: #545961;
-$gcds-file-uploader-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-file-uploader-file-border-color: #7d828b;
 $gcds-file-uploader-file-border-width: 0.125rem;
 $gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -521,9 +437,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font:
-  400 85%/120% 'Noto Sans',
-  sans-serif;
+$gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -578,42 +492,18 @@ $gcds-heading-h1-border-background: #d3080c;
 $gcds-heading-h1-border-height: 0.375rem;
 $gcds-heading-h1-border-margin: 0.5625rem;
 $gcds-heading-h1-border-width: 4.5rem;
-$gcds-heading-h1-desktop:
-  700 2.5341081619262695rem/118.38484422541731% 'Lato',
-  sans-serif;
-$gcds-heading-h1-mobile:
-  700 2.0272865295410156rem/123.31754606814303% 'Lato',
-  sans-serif;
-$gcds-heading-h2-desktop:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
-$gcds-heading-h2-mobile:
-  700 1.802032470703125rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h3-desktop:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-heading-h3-mobile:
-  700 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h4-desktop:
-  700 1.77978515625rem/126.41975308641973% 'Lato',
-  sans-serif;
-$gcds-heading-h4-mobile:
-  700 1.423828125rem/122.90809327846364% 'Lato',
-  sans-serif;
-$gcds-heading-h5-desktop:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
-$gcds-heading-h5-mobile:
-  700 1.265625rem/138.27160493827162% 'Lato',
-  sans-serif;
-$gcds-heading-h6-desktop:
-  700 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
-$gcds-heading-h6-mobile:
-  700 1.125rem/133.33333333333334% 'Lato',
-  sans-serif;
+$gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+$gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+$gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+$gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+$gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+$gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+$gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+$gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+$gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
 $gcds-heading-spacing-0: 0;
 $gcds-heading-spacing-50: 0.1875rem;
 $gcds-heading-spacing-100: 0.375rem;
@@ -630,11 +520,9 @@ $gcds-heading-spacing-700: 6rem;
 $gcds-heading-spacing-800: 7.5rem;
 $gcds-heading-spacing-900: 9rem;
 $gcds-heading-spacing-1000: 10.5rem;
-$gcds-hint-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 1.125rem;
-$gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+$gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
 $gcds-icon-font-size-caption: 1.1111111111111112rem;
 $gcds-icon-font-size-text: 1.25rem;
 $gcds-icon-font-size-h6: 1.40625rem;
@@ -684,19 +572,13 @@ $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
 $gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
-$gcds-input-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
 $gcds-input-min-width-and-height: 3rem;
 $gcds-input-outline-width: 0.1875rem;
 $gcds-input-padding: 0.75rem;
-$gcds-label-font-desktop:
-  600 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-label-font-mobile:
-  600 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-default-text: #2b4380;
@@ -707,9 +589,7 @@ $gcds-lang-toggle-focus-border-radius: 0.1875rem;
 $gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-lang-toggle-focus-outline-offset: 0.125rem;
 $gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-$gcds-lang-toggle-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-lang-toggle-hover-text: #0535d2;
 $gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
 $gcds-lang-toggle-padding: 0.5625rem;
@@ -744,10 +624,8 @@ $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
 $gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
 $gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-group-trigger-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-group-trigger-hover-text: #0535d2;
 $gcds-nav-group-trigger-max-width: 20rem;
 $gcds-nav-group-trigger-padding: 0.9375rem;
@@ -766,10 +644,8 @@ $gcds-nav-link-focus-text: #ffffff;
 $gcds-nav-link-focus-border-radius: 0.1875rem;
 $gcds-nav-link-focus-outline-offset: 0.125rem;
 $gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-link-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-link-hover-decoration-thickness: 0.125rem;
 $gcds-nav-link-hover-text: #0535d2;
 $gcds-nav-link-margin: 0.5625rem;
@@ -777,9 +653,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font:
-  600 1.58203125rem/126.41975308641975% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;
@@ -795,28 +669,24 @@ $gcds-pagination-focus-background: #0535d2;
 $gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
-$gcds-pagination-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
 $gcds-pagination-listitem-margin: 0.375rem;
 $gcds-pagination-mobile-list-border: #2b4380;
-$gcds-pagination-mobile-list-item-margin: 0.125rem;
+$gcds-pagination-mobile-list-item-margin: .125rem;
 $gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
 $gcds-pagination-simple-label-font-weight: 400;
 $gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
 $gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
 $gcds-pagination-simple-padding: 0.75rem 0.5625rem;
 $gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-$gcds-phase-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-phase-banner-icon-margin: 1.125rem;
 $gcds-phase-banner-icon-max-height: 1.125rem;
 $gcds-phase-banner-padding: 0.9375rem;
 $gcds-phase-banner-primary-background: #26374a;
 $gcds-phase-banner-primary-text: #ffffff;
-$gcds-phase-banner-secondary-background: #d6d9dd;
+$gcds-phase-banner-secondary-background: #f1f2f3;
 $gcds-phase-banner-secondary-text: #333333;
 $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
@@ -832,14 +702,10 @@ $gcds-radio-focus-background: #ffffff;
 $gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
-$gcds-radio-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-radio-input-border-width: 0.125rem;
 $gcds-radio-input-height-and-width: 3rem;
-$gcds-radio-hint-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 0 0 1.125rem;
 $gcds-radio-max-width: 46.5rem;
@@ -851,9 +717,7 @@ $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
-$gcds-search-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-search-margin: 0 0 0.1875rem;
 $gcds-search-min-width-and-height: 3rem;
 $gcds-search-outline-width: 0.1875rem;
@@ -868,16 +732,12 @@ $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
 $gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
-$gcds-select-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
 $gcds-select-min-width-and-height: 3rem;
 $gcds-select-outline-width: 0.1875rem;
 $gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-$gcds-side-nav-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
@@ -886,9 +746,7 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font:
-  600 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
+$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
@@ -900,9 +758,7 @@ $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
 $gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
-$gcds-textarea-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;
 $gcds-textarea-min-height: 3rem;
 $gcds-textarea-outline-width: 0.1875rem;
@@ -915,9 +771,7 @@ $gcds-topic-menu-button-border: #26374a;
 $gcds-topic-menu-button-expanded-background: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-border-color: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-text: #ffffff;
-$gcds-topic-menu-button-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-button-home-background: #ffffff;
 $gcds-topic-menu-button-home-border-color: #ffffff;
 $gcds-topic-menu-button-home-text: #284162; // Colour mandated by policy: link colour
@@ -929,17 +783,13 @@ $gcds-topic-menu-focus-border-radius: 0.1875rem;
 $gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-topic-menu-focus-outline-offset: 0.125rem;
 $gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-$gcds-topic-menu-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-max-width: 71.25rem;
 $gcds-topic-menu-menuitem-border-block-end: #545961;
 $gcds-topic-menu-menuitem-border-inline-end: #ffffff;
 $gcds-topic-menu-menuitem-expanded-background: #ffffff;
 $gcds-topic-menu-menuitem-expanded-text: #333333;
-$gcds-topic-menu-menuitem-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
 $gcds-topic-menu-menuitem-text: #ffffff;
 $gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -958,14 +808,10 @@ $gcds-topic-menu-mobile-topiclist-item-first-menuitem-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
-$gcds-topic-menu-mostrequested-item-first-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
 $gcds-topic-menu-mostrequested-item-width: 100%;
 $gcds-topic-menu-themelist-background: #444; // Colour mandated by policy
@@ -974,11 +820,8 @@ $gcds-topic-menu-themelist-text: #ffffff;
 $gcds-topic-menu-themelist-width: 100%;
 $gcds-topic-menu-topiclist-background: #ffffff;
 $gcds-topic-menu-topiclist-border: #d6d9dd;
-$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-  rgba(0, 0, 0, 0.1);
-$gcds-topic-menu-topiclist-item-first-font:
-  700 2.00225830078125rem/124.85901539399482% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+$gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
 $gcds-topic-menu-topiclist-item-first-width: 100%;
 $gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -988,16 +831,14 @@ $gcds-topic-menu-topiclist-margin-block-end: 1.5rem;
 $gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
 $gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-$gcds-topic-menu-topiclist-menuitem-popup-font:
-  700 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
 $gcds-topic-menu-topiclist-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-topiclist-min-height: 49.1825rem;
 $gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
 $gcds-topic-menu-topiclist-text: #000000;
 $gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-$gcds-verify-banner-background: #d6d9dd;
+$gcds-verify-banner-background: #f1f2f3;
 $gcds-verify-banner-container-xs: 20rem;
 $gcds-verify-banner-container-sm: 30rem;
 $gcds-verify-banner-container-md: 48rem;
@@ -1012,9 +853,7 @@ $gcds-verify-banner-content-list-margin: 0 0 1.5rem;
 $gcds-verify-banner-content-list-svg-margin: 0.1875rem;
 $gcds-verify-banner-content-padding-block-start: 1.5rem;
 $gcds-verify-banner-content-padding-block-end: 0.75rem;
-$gcds-verify-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-verify-banner-summary-padding: 0.75rem;
 $gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
 $gcds-verify-banner-text: #333333;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,5 +1,6 @@
+
 // Do not edit directly
-// Generated on Thu, 04 Apr 2024 18:09:57 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
@@ -7,36 +8,20 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-radius: 0.1875rem;
 $gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-link-font-small-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-small-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+$gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
 $gcds-link-decoration-thickness: 0.0625rem;
 $gcds-link-underline-offset: 0.25rem;
 $gcds-text-character-limit: 65ch;
 $gcds-text-role-light: #ffffff;
 $gcds-text-role-primary: #333333;
 $gcds-text-role-secondary: #43474e;
-$gcds-text-size-body-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-body-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
+$gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+$gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
 $gcds-text-spacing-0: 0;
 $gcds-text-spacing-50: 0.1875rem;
 $gcds-text-spacing-100: 0.375rem;
@@ -89,16 +74,12 @@ $gcds-alert-button-icon-width-and-height: 1.125rem;
 $gcds-alert-button-margin: 0 0 0 0.9375rem;
 $gcds-alert-button-mobile-margin: 0.9375rem 0 0;
 $gcds-alert-button-outline-width: 0.1875rem;
-$gcds-alert-content-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-alert-content-heading-margin: 0 0 0.5625rem;
 $gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
 $gcds-alert-content-slotted-list-margin: 1.5rem;
 $gcds-alert-content-slotted-margin: 0.5625rem;
-$gcds-alert-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-alert-icon-font-size: 2.25rem;
 $gcds-alert-icon-margin: 0 0.9375rem 0 0;
 $gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -124,9 +105,7 @@ $gcds-breadcrumbs-focus-text: #ffffff;
 $gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
 $gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-$gcds-breadcrumbs-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-breadcrumbs-hover-text: #0535d2;
 $gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
 $gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -142,9 +121,7 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-button-padding: 0.75rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
@@ -164,9 +141,7 @@ $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
 $gcds-button-shared-disabled-text: #545961;
 $gcds-button-skip-top: 1.5rem;
-$gcds-button-small-font:
-  400 80%/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
 $gcds-button-small-padding: 0.75rem;
 $gcds-button-width: fit-content;
 $gcds-card-background-color: #ffffff;
@@ -187,17 +162,11 @@ $gcds-card-hover-title-text-decoration-thickness: 0.125rem;
 $gcds-card-margin: 0 0 1.5rem;
 $gcds-card-padding: 1.5rem;
 $gcds-card-tag-color: #43474e;
-$gcds-card-tag-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-slot-color: #43474e;
-$gcds-card-slot-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-title-color: #2b4380;
-$gcds-card-title-font:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
+$gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
 $gcds-card-title-text-decoration-thickness: 0.0625rem;
 $gcds-card-title-text-underline-offset: 0.125rem;
 $gcds-checkbox-check-border-width: 0.3125rem;
@@ -215,9 +184,7 @@ $gcds-checkbox-focus-background: #ffffff;
 $gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
-$gcds-checkbox-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-checkbox-input-border-radius: 0.1875rem;
 $gcds-checkbox-input-border-width: 0.125rem;
 $gcds-checkbox-input-height-and-width: 3rem;
@@ -226,9 +193,7 @@ $gcds-checkbox-margin: 0 0 1.125rem;
 $gcds-checkbox-max-width: 46.5rem;
 $gcds-checkbox-padding: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-$gcds-date-modified-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-date-modified-margin: 3rem 0 1.5rem;
 $gcds-date-modified-text: #333333;
 $gcds-details-default-text: #2b4380;
@@ -239,12 +204,8 @@ $gcds-details-focus-border-radius: 0.1875rem;
 $gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-details-focus-outline-offset: 0.125rem;
 $gcds-details-focus-outline: 0.1875rem solid #0535d2;
-$gcds-details-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-details-font-small:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-details-hover-text: #0535d2;
 $gcds-details-hover-decoration-thickness: 0.125rem;
 $gcds-details-panel-border-color: #7d828b;
@@ -261,9 +222,7 @@ $gcds-details-summary-padding: 0.375rem 0.375rem 0.375rem 2.25rem;
 $gcds-error-message-background: #fbddda;
 $gcds-error-message-border-color: #d3080c;
 $gcds-error-message-border-width: 0.125rem;
-$gcds-error-message-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-message-text: #333333;
@@ -276,9 +235,7 @@ $gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
 $gcds-error-summary-focus-link-outline-offset: 0.125rem;
 $gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
+$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
 $gcds-error-summary-hover-link-thickness: 0.125rem;
 $gcds-error-summary-link-color: #a62a1e;
@@ -293,12 +250,8 @@ $gcds-error-summary-padding: 2.25rem;
 $gcds-fieldset-default-text: #333333;
 $gcds-fieldset-disabled-text: #545961;
 $gcds-fieldset-focus-text: #0535d2;
-$gcds-fieldset-font-desktop:
-  600 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-fieldset-font-mobile:
-  600 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
+$gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
 $gcds-fieldset-legend-margin: 0 0 0.1875rem;
 $gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
 $gcds-file-uploader-button-background: #ffffff;
@@ -312,9 +265,7 @@ $gcds-file-uploader-button-text: #2b4380;
 $gcds-file-uploader-default-text: #333333;
 $gcds-file-uploader-disabled-background: #d6d9dd;
 $gcds-file-uploader-disabled-text: #545961;
-$gcds-file-uploader-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-file-uploader-file-border-color: #7d828b;
 $gcds-file-uploader-file-border-width: 0.125rem;
 $gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -343,9 +294,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font:
-  400 85%/120% 'Noto Sans',
-  sans-serif;
+$gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -400,42 +349,18 @@ $gcds-heading-h1-border-background: #d3080c;
 $gcds-heading-h1-border-height: 0.375rem;
 $gcds-heading-h1-border-margin: 0.5625rem;
 $gcds-heading-h1-border-width: 4.5rem;
-$gcds-heading-h1-desktop:
-  700 2.5341081619262695rem/118.38484422541731% 'Lato',
-  sans-serif;
-$gcds-heading-h1-mobile:
-  700 2.0272865295410156rem/123.31754606814303% 'Lato',
-  sans-serif;
-$gcds-heading-h2-desktop:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
-$gcds-heading-h2-mobile:
-  700 1.802032470703125rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h3-desktop:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-heading-h3-mobile:
-  700 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h4-desktop:
-  700 1.77978515625rem/126.41975308641973% 'Lato',
-  sans-serif;
-$gcds-heading-h4-mobile:
-  700 1.423828125rem/122.90809327846364% 'Lato',
-  sans-serif;
-$gcds-heading-h5-desktop:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
-$gcds-heading-h5-mobile:
-  700 1.265625rem/138.27160493827162% 'Lato',
-  sans-serif;
-$gcds-heading-h6-desktop:
-  700 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
-$gcds-heading-h6-mobile:
-  700 1.125rem/133.33333333333334% 'Lato',
-  sans-serif;
+$gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+$gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+$gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+$gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+$gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+$gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+$gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+$gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+$gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
 $gcds-heading-spacing-0: 0;
 $gcds-heading-spacing-50: 0.1875rem;
 $gcds-heading-spacing-100: 0.375rem;
@@ -452,11 +377,9 @@ $gcds-heading-spacing-700: 6rem;
 $gcds-heading-spacing-800: 7.5rem;
 $gcds-heading-spacing-900: 9rem;
 $gcds-heading-spacing-1000: 10.5rem;
-$gcds-hint-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 1.125rem;
-$gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+$gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
 $gcds-icon-font-size-caption: 1.1111111111111112rem;
 $gcds-icon-font-size-text: 1.25rem;
 $gcds-icon-font-size-h6: 1.40625rem;
@@ -506,19 +429,13 @@ $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
 $gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
-$gcds-input-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
 $gcds-input-min-width-and-height: 3rem;
 $gcds-input-outline-width: 0.1875rem;
 $gcds-input-padding: 0.75rem;
-$gcds-label-font-desktop:
-  600 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-label-font-mobile:
-  600 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-default-text: #2b4380;
@@ -529,9 +446,7 @@ $gcds-lang-toggle-focus-border-radius: 0.1875rem;
 $gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-lang-toggle-focus-outline-offset: 0.125rem;
 $gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-$gcds-lang-toggle-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-lang-toggle-hover-text: #0535d2;
 $gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
 $gcds-lang-toggle-padding: 0.5625rem;
@@ -566,10 +481,8 @@ $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
 $gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
 $gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-group-trigger-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-group-trigger-hover-text: #0535d2;
 $gcds-nav-group-trigger-max-width: 20rem;
 $gcds-nav-group-trigger-padding: 0.9375rem;
@@ -588,10 +501,8 @@ $gcds-nav-link-focus-text: #ffffff;
 $gcds-nav-link-focus-border-radius: 0.1875rem;
 $gcds-nav-link-focus-outline-offset: 0.125rem;
 $gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-link-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-link-hover-decoration-thickness: 0.125rem;
 $gcds-nav-link-hover-text: #0535d2;
 $gcds-nav-link-margin: 0.5625rem;
@@ -599,9 +510,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font:
-  600 1.58203125rem/126.41975308641975% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;
@@ -617,28 +526,24 @@ $gcds-pagination-focus-background: #0535d2;
 $gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
-$gcds-pagination-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
 $gcds-pagination-listitem-margin: 0.375rem;
 $gcds-pagination-mobile-list-border: #2b4380;
-$gcds-pagination-mobile-list-item-margin: 0.125rem;
+$gcds-pagination-mobile-list-item-margin: .125rem;
 $gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
 $gcds-pagination-simple-label-font-weight: 400;
 $gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
 $gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
 $gcds-pagination-simple-padding: 0.75rem 0.5625rem;
 $gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-$gcds-phase-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-phase-banner-icon-margin: 1.125rem;
 $gcds-phase-banner-icon-max-height: 1.125rem;
 $gcds-phase-banner-padding: 0.9375rem;
 $gcds-phase-banner-primary-background: #26374a;
 $gcds-phase-banner-primary-text: #ffffff;
-$gcds-phase-banner-secondary-background: #d6d9dd;
+$gcds-phase-banner-secondary-background: #f1f2f3;
 $gcds-phase-banner-secondary-text: #333333;
 $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
@@ -654,14 +559,10 @@ $gcds-radio-focus-background: #ffffff;
 $gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
-$gcds-radio-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-radio-input-border-width: 0.125rem;
 $gcds-radio-input-height-and-width: 3rem;
-$gcds-radio-hint-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 0 0 1.125rem;
 $gcds-radio-max-width: 46.5rem;
@@ -673,9 +574,7 @@ $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
-$gcds-search-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-search-margin: 0 0 0.1875rem;
 $gcds-search-min-width-and-height: 3rem;
 $gcds-search-outline-width: 0.1875rem;
@@ -690,16 +589,12 @@ $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
 $gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
-$gcds-select-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
 $gcds-select-min-width-and-height: 3rem;
 $gcds-select-outline-width: 0.1875rem;
 $gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-$gcds-side-nav-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
@@ -708,9 +603,7 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font:
-  600 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
+$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
@@ -722,9 +615,7 @@ $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
 $gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
-$gcds-textarea-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;
 $gcds-textarea-min-height: 3rem;
 $gcds-textarea-outline-width: 0.1875rem;
@@ -737,9 +628,7 @@ $gcds-topic-menu-button-border: #26374a;
 $gcds-topic-menu-button-expanded-background: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-border-color: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-text: #ffffff;
-$gcds-topic-menu-button-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-button-home-background: #ffffff;
 $gcds-topic-menu-button-home-border-color: #ffffff;
 $gcds-topic-menu-button-home-text: #284162; // Colour mandated by policy: link colour
@@ -751,17 +640,13 @@ $gcds-topic-menu-focus-border-radius: 0.1875rem;
 $gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-topic-menu-focus-outline-offset: 0.125rem;
 $gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-$gcds-topic-menu-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-max-width: 71.25rem;
 $gcds-topic-menu-menuitem-border-block-end: #545961;
 $gcds-topic-menu-menuitem-border-inline-end: #ffffff;
 $gcds-topic-menu-menuitem-expanded-background: #ffffff;
 $gcds-topic-menu-menuitem-expanded-text: #333333;
-$gcds-topic-menu-menuitem-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
 $gcds-topic-menu-menuitem-text: #ffffff;
 $gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -780,14 +665,10 @@ $gcds-topic-menu-mobile-topiclist-item-first-menuitem-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
-$gcds-topic-menu-mostrequested-item-first-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
 $gcds-topic-menu-mostrequested-item-width: 100%;
 $gcds-topic-menu-themelist-background: #444; // Colour mandated by policy
@@ -796,11 +677,8 @@ $gcds-topic-menu-themelist-text: #ffffff;
 $gcds-topic-menu-themelist-width: 100%;
 $gcds-topic-menu-topiclist-background: #ffffff;
 $gcds-topic-menu-topiclist-border: #d6d9dd;
-$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-  rgba(0, 0, 0, 0.1);
-$gcds-topic-menu-topiclist-item-first-font:
-  700 2.00225830078125rem/124.85901539399482% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+$gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
 $gcds-topic-menu-topiclist-item-first-width: 100%;
 $gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -810,16 +688,14 @@ $gcds-topic-menu-topiclist-margin-block-end: 1.5rem;
 $gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
 $gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-$gcds-topic-menu-topiclist-menuitem-popup-font:
-  700 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
 $gcds-topic-menu-topiclist-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-topiclist-min-height: 49.1825rem;
 $gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
 $gcds-topic-menu-topiclist-text: #000000;
 $gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-$gcds-verify-banner-background: #d6d9dd;
+$gcds-verify-banner-background: #f1f2f3;
 $gcds-verify-banner-container-xs: 20rem;
 $gcds-verify-banner-container-sm: 30rem;
 $gcds-verify-banner-container-md: 48rem;
@@ -834,9 +710,7 @@ $gcds-verify-banner-content-list-margin: 0 0 1.5rem;
 $gcds-verify-banner-content-list-svg-margin: 0.1875rem;
 $gcds-verify-banner-content-padding-block-start: 1.5rem;
 $gcds-verify-banner-content-padding-block-end: 0.75rem;
-$gcds-verify-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-verify-banner-summary-padding: 0.75rem;
 $gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
 $gcds-verify-banner-text: #333333;

--- a/build/web/scss/components/phase-banner.scss
+++ b/build/web/scss/components/phase-banner.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 22 Jun 2023 14:47:37 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
 $gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
 $gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
@@ -9,5 +9,5 @@ $gcds-phase-banner-icon-max-height: 1.125rem;
 $gcds-phase-banner-padding: 0.9375rem;
 $gcds-phase-banner-primary-background: #26374a;
 $gcds-phase-banner-primary-text: #ffffff;
-$gcds-phase-banner-secondary-background: #d6d9dd;
+$gcds-phase-banner-secondary-background: #f1f2f3;
 $gcds-phase-banner-secondary-text: #333333;

--- a/build/web/scss/components/verify-banner.scss
+++ b/build/web/scss/components/verify-banner.scss
@@ -1,8 +1,8 @@
 
 // Do not edit directly
-// Generated on Tue, 27 Jun 2023 23:49:41 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
-$gcds-verify-banner-background: #d6d9dd;
+$gcds-verify-banner-background: #f1f2f3;
 $gcds-verify-banner-container-xs: 20rem;
 $gcds-verify-banner-container-sm: 30rem;
 $gcds-verify-banner-container-md: 48rem;

--- a/build/web/scss/global.scss
+++ b/build/web/scss/global.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 05 Oct 2023 20:45:21 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
 $gcds-border-radius-sm: 0.1875rem; // Global border: radius sm
 $gcds-border-radius-md: 0.375rem; // Global border: radius md
@@ -13,6 +13,11 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
+$gcds-bg-black: #000000; // Global bg color: black background
+$gcds-bg-dark: #333333; // Global bg color: dark background
+$gcds-bg-light: #f1f2f3; // Global bg color: light background
+$gcds-bg-primary: #26374a; // Global bg color: primary background
+$gcds-bg-white: #ffffff; // Global bg color: white background
 $gcds-danger-background: #fbddda; // Global color: danger background
 $gcds-danger-border: #d3080c; // Global color: danger border
 $gcds-danger-text: #a62a1e; // Global color: danger text

--- a/build/web/scss/global/color.scss
+++ b/build/web/scss/global/color.scss
@@ -1,10 +1,15 @@
 
 // Do not edit directly
-// Generated on Mon, 19 Jun 2023 20:28:18 GMT
+// Generated on Mon, 15 Apr 2024 23:56:04 GMT
 
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
+$gcds-bg-black: #000000; // Global bg color: black background
+$gcds-bg-dark: #333333; // Global bg color: dark background
+$gcds-bg-light: #f1f2f3; // Global bg color: light background
+$gcds-bg-primary: #26374a; // Global bg color: primary background
+$gcds-bg-white: #ffffff; // Global bg color: white background
 $gcds-danger-background: #fbddda; // Global color: danger background
 $gcds-danger-border: #d3080c; // Global color: danger border
 $gcds-danger-text: #a62a1e; // Global color: danger text

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,5 +1,6 @@
+
 // Do not edit directly
-// Generated on Thu, 04 Apr 2024 18:09:57 GMT
+// Generated on Mon, 15 Apr 2024 23:56:03 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -37,6 +38,11 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
+$gcds-bg-black: #000000; // Global bg color: black background
+$gcds-bg-dark: #333333; // Global bg color: dark background
+$gcds-bg-light: #f1f2f3; // Global bg color: light background
+$gcds-bg-primary: #26374a; // Global bg color: primary background
+$gcds-bg-white: #ffffff; // Global bg color: white background
 $gcds-danger-background: #fbddda; // Global color: danger background
 $gcds-danger-border: #d3080c; // Global color: danger border
 $gcds-danger-text: #a62a1e; // Global color: danger text
@@ -54,18 +60,10 @@ $gcds-link-focus-outline-offset: 0.125rem;
 $gcds-link-focus-text: #ffffff;
 $gcds-link-focus-border-radius: 0.1875rem;
 $gcds-link-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-link-font-small-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-small-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-link-font-regular-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-link-font-small-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-link-font-small-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+$gcds-link-font-regular-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-link-font-regular-mobile: 400 1rem/150% "Noto Sans", sans-serif;
 $gcds-link-decoration-thickness: 0.0625rem;
 $gcds-link-underline-offset: 0.25rem;
 $gcds-text-light: #ffffff; // Global color: text light
@@ -75,18 +73,10 @@ $gcds-text-character-limit: 65ch;
 $gcds-text-role-light: #ffffff;
 $gcds-text-role-primary: #333333;
 $gcds-text-role-secondary: #43474e;
-$gcds-text-size-body-desktop:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-body-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-desktop:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-text-size-caption-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
+$gcds-text-size-body-desktop: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-text-size-body-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+$gcds-text-size-caption-desktop: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-text-size-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
 $gcds-text-spacing-0: 0;
 $gcds-text-spacing-50: 0.1875rem;
 $gcds-text-spacing-100: 0.375rem;
@@ -154,10 +144,10 @@ $gcds-base-font-size: 1.25; // Sets base font size to 20px
 $gcds-base-font-size-mobile: 1; // Sets base font size for smaller screens to 16px
 $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
-$gcds-font-families-heading: 'Lato', sans-serif;
-$gcds-font-families-body: 'Noto Sans', sans-serif;
-$gcds-font-families-monospace: 'Menlo', sans-serif;
-$gcds-font-families-icons: 'Font Awesome 6 Free', FontAwesome;
+$gcds-font-families-heading: "Lato", sans-serif;
+$gcds-font-families-body: "Noto Sans", sans-serif;
+$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;
 $gcds-font-sizes-text: 1.25rem;
@@ -195,66 +185,26 @@ $gcds-line-heights-h2: 122.08437060746162%;
 $gcds-line-heights-h2-mobile: 124.85901539399481%;
 $gcds-line-heights-h1: 118.38484422541731%;
 $gcds-line-heights-h1-mobile: 123.31754606814303%;
-$gcds-font-h1:
-  700 2.5341081619262695rem/118.38484422541731% 'Lato',
-  sans-serif;
-$gcds-font-h1-mobile:
-  700 2.0272865295410156rem/123.31754606814303% 'Lato',
-  sans-serif;
-$gcds-font-h2:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
-$gcds-font-h2-mobile:
-  700 1.802032470703125rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-font-h3:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-font-h3-mobile:
-  700 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-font-h4:
-  700 1.77978515625rem/126.41975308641973% 'Lato',
-  sans-serif;
-$gcds-font-h4-mobile:
-  700 1.423828125rem/122.90809327846364% 'Lato',
-  sans-serif;
-$gcds-font-h5:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
-$gcds-font-h5-mobile:
-  700 1.265625rem/138.27160493827162% 'Lato',
-  sans-serif;
-$gcds-font-h6:
-  700 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
-$gcds-font-h6-mobile:
-  700 1.125rem/133.33333333333334% 'Lato',
-  sans-serif;
-$gcds-font-label:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-font-label-mobile:
-  500 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-caption:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
-$gcds-font-caption-mobile:
-  400 0.8888888888888888rem/140.625% 'Noto Sans',
-  sans-serif;
-$gcds-font-text:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-long:
-  400 1.25rem/150% 'Noto Sans',
-  sans-serif;
-$gcds-font-text-long-mobile:
-  400 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-font-h1: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+$gcds-font-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+$gcds-font-h2: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+$gcds-font-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+$gcds-font-h3: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-font-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+$gcds-font-h4: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+$gcds-font-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+$gcds-font-h5: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+$gcds-font-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+$gcds-font-h6: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+$gcds-font-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
+$gcds-font-label: 500 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-font-label-mobile: 500 1rem/150% "Noto Sans", sans-serif;
+$gcds-font-caption: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
+$gcds-font-caption-mobile: 400 0.8888888888888888rem/140.625% "Noto Sans", sans-serif;
+$gcds-font-text: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-font-text-mobile: 400 1rem/150% "Noto Sans", sans-serif;
+$gcds-font-text-long: 400 1.25rem/150% "Noto Sans", sans-serif;
+$gcds-font-text-long-mobile: 400 1rem/150% "Noto Sans", sans-serif;
 $gcds-alert-border-width: 0.375rem;
 $gcds-alert-button-border-radius: 0.375rem;
 $gcds-alert-button-border-width: 0.125rem;
@@ -267,16 +217,12 @@ $gcds-alert-button-icon-width-and-height: 1.125rem;
 $gcds-alert-button-margin: 0 0 0 0.9375rem;
 $gcds-alert-button-mobile-margin: 0.9375rem 0 0;
 $gcds-alert-button-outline-width: 0.1875rem;
-$gcds-alert-content-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-alert-content-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-alert-content-heading-margin: 0 0 0.5625rem;
 $gcds-alert-content-heading-mobile-margin: 0 0 0.5625rem;
 $gcds-alert-content-slotted-list-margin: 1.5rem;
 $gcds-alert-content-slotted-margin: 0.5625rem;
-$gcds-alert-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-alert-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-alert-icon-font-size: 2.25rem;
 $gcds-alert-icon-margin: 0 0.9375rem 0 0;
 $gcds-alert-icon-mobile-margin: 0 0 0.9375rem;
@@ -302,9 +248,7 @@ $gcds-breadcrumbs-focus-text: #ffffff;
 $gcds-breadcrumbs-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-breadcrumbs-focus-outline: 0.1875rem solid #0535d2;
 $gcds-breadcrumbs-focus-outline-offset: 0.125rem;
-$gcds-breadcrumbs-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-breadcrumbs-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-breadcrumbs-hover-text: #0535d2;
 $gcds-breadcrumbs-hover-decoration-thickness: 0.125rem;
 $gcds-breadcrumbs-item-arrow-top: 0.9375rem;
@@ -320,9 +264,7 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-button-padding: 0.75rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
@@ -342,9 +284,7 @@ $gcds-button-shared-focus-text: #ffffff;
 $gcds-button-shared-disabled-background: #d6d9dd;
 $gcds-button-shared-disabled-text: #545961;
 $gcds-button-skip-top: 1.5rem;
-$gcds-button-small-font:
-  400 80%/120% 'Noto Sans',
-  sans-serif;
+$gcds-button-small-font: 400 80%/120% "Noto Sans", sans-serif;
 $gcds-button-small-padding: 0.75rem;
 $gcds-button-width: fit-content;
 $gcds-card-background-color: #ffffff;
@@ -365,17 +305,11 @@ $gcds-card-hover-title-text-decoration-thickness: 0.125rem;
 $gcds-card-margin: 0 0 1.5rem;
 $gcds-card-padding: 1.5rem;
 $gcds-card-tag-color: #43474e;
-$gcds-card-tag-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-tag-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-slot-color: #43474e;
-$gcds-card-slot-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-card-slot-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-card-title-color: #2b4380;
-$gcds-card-title-font:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
+$gcds-card-title-font: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
 $gcds-card-title-text-decoration-thickness: 0.0625rem;
 $gcds-card-title-text-underline-offset: 0.125rem;
 $gcds-checkbox-check-border-width: 0.3125rem;
@@ -393,9 +327,7 @@ $gcds-checkbox-focus-background: #ffffff;
 $gcds-checkbox-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-checkbox-focus-text: #0535d2;
 $gcds-checkbox-focus-outline-width: 0.1875rem;
-$gcds-checkbox-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-checkbox-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-checkbox-input-border-radius: 0.1875rem;
 $gcds-checkbox-input-border-width: 0.125rem;
 $gcds-checkbox-input-height-and-width: 3rem;
@@ -404,9 +336,7 @@ $gcds-checkbox-margin: 0 0 1.125rem;
 $gcds-checkbox-max-width: 46.5rem;
 $gcds-checkbox-padding: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.1875rem;
-$gcds-date-modified-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-date-modified-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-date-modified-margin: 3rem 0 1.5rem;
 $gcds-date-modified-text: #333333;
 $gcds-details-default-text: #2b4380;
@@ -417,12 +347,8 @@ $gcds-details-focus-border-radius: 0.1875rem;
 $gcds-details-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-details-focus-outline-offset: 0.125rem;
 $gcds-details-focus-outline: 0.1875rem solid #0535d2;
-$gcds-details-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-details-font-small:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-details-font: 400 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-details-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-details-hover-text: #0535d2;
 $gcds-details-hover-decoration-thickness: 0.125rem;
 $gcds-details-panel-border-color: #7d828b;
@@ -439,9 +365,7 @@ $gcds-details-summary-padding: 0.375rem 0.375rem 0.375rem 2.25rem;
 $gcds-error-message-background: #fbddda;
 $gcds-error-message-border-color: #d3080c;
 $gcds-error-message-border-width: 0.125rem;
-$gcds-error-message-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-error-message-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-message-text: #333333;
@@ -454,9 +378,7 @@ $gcds-error-summary-focus-link-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-error-summary-focus-link-outline: 0.1875rem solid #0535d2;
 $gcds-error-summary-focus-link-outline-offset: 0.125rem;
 $gcds-error-summary-focus-link-text: #ffffff;
-$gcds-error-summary-heading-font:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
+$gcds-error-summary-heading-font: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
 $gcds-error-summary-heading-padding-bottom: 1.125rem;
 $gcds-error-summary-hover-link-thickness: 0.125rem;
 $gcds-error-summary-link-color: #a62a1e;
@@ -471,12 +393,8 @@ $gcds-error-summary-padding: 2.25rem;
 $gcds-fieldset-default-text: #333333;
 $gcds-fieldset-disabled-text: #545961;
 $gcds-fieldset-focus-text: #0535d2;
-$gcds-fieldset-font-desktop:
-  600 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-fieldset-font-mobile:
-  600 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
+$gcds-fieldset-font-desktop: 600 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-fieldset-font-mobile: 600 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
 $gcds-fieldset-legend-margin: 0 0 0.1875rem;
 $gcds-fieldset-legend-required-margin: 0 0 0 0.375rem;
 $gcds-file-uploader-button-background: #ffffff;
@@ -490,9 +408,7 @@ $gcds-file-uploader-button-text: #2b4380;
 $gcds-file-uploader-default-text: #333333;
 $gcds-file-uploader-disabled-background: #d6d9dd;
 $gcds-file-uploader-disabled-text: #545961;
-$gcds-file-uploader-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-file-uploader-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-file-uploader-file-border-color: #7d828b;
 $gcds-file-uploader-file-border-width: 0.125rem;
 $gcds-file-uploader-file-button-border-width: 0.0625rem;
@@ -521,9 +437,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font:
-  400 85%/120% 'Noto Sans',
-  sans-serif;
+$gcds-footer-font: 400 85%/120% "Noto Sans", sans-serif;
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 1.125rem;
@@ -578,42 +492,18 @@ $gcds-heading-h1-border-background: #d3080c;
 $gcds-heading-h1-border-height: 0.375rem;
 $gcds-heading-h1-border-margin: 0.5625rem;
 $gcds-heading-h1-border-width: 4.5rem;
-$gcds-heading-h1-desktop:
-  700 2.5341081619262695rem/118.38484422541731% 'Lato',
-  sans-serif;
-$gcds-heading-h1-mobile:
-  700 2.0272865295410156rem/123.31754606814303% 'Lato',
-  sans-serif;
-$gcds-heading-h2-desktop:
-  700 2.2525405883789062rem/122.08437060746162% 'Lato',
-  sans-serif;
-$gcds-heading-h2-mobile:
-  700 1.802032470703125rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h3-desktop:
-  700 2.00225830078125rem/124.85901539399482% 'Lato',
-  sans-serif;
-$gcds-heading-h3-mobile:
-  700 1.601806640625rem/124.85901539399481% 'Lato',
-  sans-serif;
-$gcds-heading-h4-desktop:
-  700 1.77978515625rem/126.41975308641973% 'Lato',
-  sans-serif;
-$gcds-heading-h4-mobile:
-  700 1.423828125rem/122.90809327846364% 'Lato',
-  sans-serif;
-$gcds-heading-h5-desktop:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
-$gcds-heading-h5-mobile:
-  700 1.265625rem/138.27160493827162% 'Lato',
-  sans-serif;
-$gcds-heading-h6-desktop:
-  700 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
-$gcds-heading-h6-mobile:
-  700 1.125rem/133.33333333333334% 'Lato',
-  sans-serif;
+$gcds-heading-h1-desktop: 700 2.5341081619262695rem/118.38484422541731% "Lato", sans-serif;
+$gcds-heading-h1-mobile: 700 2.0272865295410156rem/123.31754606814303% "Lato", sans-serif;
+$gcds-heading-h2-desktop: 700 2.2525405883789062rem/122.08437060746162% "Lato", sans-serif;
+$gcds-heading-h2-mobile: 700 1.802032470703125rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h3-desktop: 700 2.00225830078125rem/124.85901539399482% "Lato", sans-serif;
+$gcds-heading-h3-mobile: 700 1.601806640625rem/124.85901539399481% "Lato", sans-serif;
+$gcds-heading-h4-desktop: 700 1.77978515625rem/126.41975308641973% "Lato", sans-serif;
+$gcds-heading-h4-mobile: 700 1.423828125rem/122.90809327846364% "Lato", sans-serif;
+$gcds-heading-h5-desktop: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
+$gcds-heading-h5-mobile: 700 1.265625rem/138.27160493827162% "Lato", sans-serif;
+$gcds-heading-h6-desktop: 700 1.40625rem/124.44444444444444% "Lato", sans-serif;
+$gcds-heading-h6-mobile: 700 1.125rem/133.33333333333334% "Lato", sans-serif;
 $gcds-heading-spacing-0: 0;
 $gcds-heading-spacing-50: 0.1875rem;
 $gcds-heading-spacing-100: 0.375rem;
@@ -630,11 +520,9 @@ $gcds-heading-spacing-700: 6rem;
 $gcds-heading-spacing-800: 7.5rem;
 $gcds-heading-spacing-900: 9rem;
 $gcds-heading-spacing-1000: 10.5rem;
-$gcds-hint-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-hint-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-hint-margin: 0 0 1.125rem;
-$gcds-icon-font-family: 'Font Awesome 6 Free', FontAwesome;
+$gcds-icon-font-family: "Font Awesome 6 Free", FontAwesome;
 $gcds-icon-font-size-caption: 1.1111111111111112rem;
 $gcds-icon-font-size-text: 1.25rem;
 $gcds-icon-font-size-h6: 1.40625rem;
@@ -684,19 +572,13 @@ $gcds-input-disabled-background: #d6d9dd;
 $gcds-input-disabled-text: #545961;
 $gcds-input-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-input-focus-text: #0535d2;
-$gcds-input-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-input-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-input-margin: 0 0 1.5rem;
 $gcds-input-min-width-and-height: 3rem;
 $gcds-input-outline-width: 0.1875rem;
 $gcds-input-padding: 0.75rem;
-$gcds-label-font-desktop:
-  600 1.25rem/120% 'Noto Sans',
-  sans-serif;
-$gcds-label-font-mobile:
-  600 1rem/150% 'Noto Sans',
-  sans-serif;
+$gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
+$gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-default-text: #2b4380;
@@ -707,9 +589,7 @@ $gcds-lang-toggle-focus-border-radius: 0.1875rem;
 $gcds-lang-toggle-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-lang-toggle-focus-outline-offset: 0.125rem;
 $gcds-lang-toggle-focus-outline: 0.1875rem solid #0535d2;
-$gcds-lang-toggle-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-lang-toggle-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-lang-toggle-hover-text: #0535d2;
 $gcds-lang-toggle-hover-decoration-thickness: 0.125rem;
 $gcds-lang-toggle-padding: 0.5625rem;
@@ -744,10 +624,8 @@ $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.1875rem;
 $gcds-nav-group-trigger-focus-outline-offset: 0.125rem;
 $gcds-nav-group-trigger-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-group-trigger-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-group-trigger-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-group-trigger-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-group-trigger-hover-text: #0535d2;
 $gcds-nav-group-trigger-max-width: 20rem;
 $gcds-nav-group-trigger-padding: 0.9375rem;
@@ -766,10 +644,8 @@ $gcds-nav-link-focus-text: #ffffff;
 $gcds-nav-link-focus-border-radius: 0.1875rem;
 $gcds-nav-link-focus-outline-offset: 0.125rem;
 $gcds-nav-link-focus-outline: 0.1875rem solid #0535d2;
-$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #fff;
-$gcds-nav-link-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-focus-box-shadow: 0 0 0 0.125rem #FFF;
+$gcds-nav-link-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-nav-link-hover-decoration-thickness: 0.125rem;
 $gcds-nav-link-hover-text: #0535d2;
 $gcds-nav-link-margin: 0.5625rem;
@@ -777,9 +653,7 @@ $gcds-nav-link-padding: 0.9375rem;
 $gcds-nav-link-side-nav-hover-background: #f1f2f3;
 $gcds-nav-link-side-nav-padding: 0.9375rem 0.75rem;
 $gcds-nav-link-top-nav-hover-background: #d6d9dd;
-$gcds-nav-link-top-nav-home-font:
-  600 1.58203125rem/126.41975308641975% 'Noto Sans',
-  sans-serif;
+$gcds-nav-link-top-nav-home-font: 600 1.58203125rem/126.41975308641975% "Noto Sans", sans-serif;
 $gcds-nav-link-top-nav-home-padding: 0.9375rem 0.1875rem;
 $gcds-nav-link-top-nav-padding: 1.125rem;
 $gcds-nav-link-top-nav-text: #333333;
@@ -795,28 +669,24 @@ $gcds-pagination-focus-background: #0535d2;
 $gcds-pagination-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-pagination-focus-text: #ffffff;
 $gcds-pagination-focus-outline-width: 0.1875rem;
-$gcds-pagination-font:
-  500 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-pagination-font: 500 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-pagination-list-end-button-padding: 0.75rem 0.5625rem;
 $gcds-pagination-listitem-margin: 0.375rem;
 $gcds-pagination-mobile-list-border: #2b4380;
-$gcds-pagination-mobile-list-item-margin: 0.125rem;
+$gcds-pagination-mobile-list-item-margin: .125rem;
 $gcds-pagination-mobile-list-prevnext-margin: 0.75rem auto 0;
 $gcds-pagination-simple-label-font-weight: 400;
 $gcds-pagination-simple-listitem-margin: 0.375rem 0.375rem 0.75rem;
 $gcds-pagination-simple-listitem-text-margin: 0 0 0.1875rem;
 $gcds-pagination-simple-padding: 0.75rem 0.5625rem;
 $gcds-phase-banner-details-cta-margin: 0 0 0 0.9375rem;
-$gcds-phase-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-phase-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-phase-banner-icon-margin: 1.125rem;
 $gcds-phase-banner-icon-max-height: 1.125rem;
 $gcds-phase-banner-padding: 0.9375rem;
 $gcds-phase-banner-primary-background: #26374a;
 $gcds-phase-banner-primary-text: #ffffff;
-$gcds-phase-banner-secondary-background: #d6d9dd;
+$gcds-phase-banner-secondary-background: #f1f2f3;
 $gcds-phase-banner-secondary-text: #333333;
 $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
@@ -832,14 +702,10 @@ $gcds-radio-focus-background: #ffffff;
 $gcds-radio-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-radio-focus-text: #0535d2;
 $gcds-radio-focus-outline-width: 0.1875rem;
-$gcds-radio-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-radio-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-radio-input-border-width: 0.125rem;
 $gcds-radio-input-height-and-width: 3rem;
-$gcds-radio-hint-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-radio-hint-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 0 0 1.125rem;
 $gcds-radio-max-width: 46.5rem;
@@ -851,9 +717,7 @@ $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.1875rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-focus-text: #0535d2;
-$gcds-search-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-search-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-search-margin: 0 0 0.1875rem;
 $gcds-search-min-width-and-height: 3rem;
 $gcds-search-outline-width: 0.1875rem;
@@ -868,16 +732,12 @@ $gcds-select-disabled-background: #d6d9dd;
 $gcds-select-disabled-text: #545961;
 $gcds-select-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-select-focus-text: #0535d2;
-$gcds-select-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-select-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-select-margin: 0 0 1.5rem;
 $gcds-select-min-width-and-height: 3rem;
 $gcds-select-outline-width: 0.1875rem;
 $gcds-select-padding: 0.75rem 3.75rem 0.75rem 0.75rem;
-$gcds-side-nav-heading-font:
-  700 1.58203125rem/126.41975308641975% 'Lato',
-  sans-serif;
+$gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-serif;
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
@@ -886,9 +746,7 @@ $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;
 $gcds-signature-wordmark-height: 3rem;
-$gcds-stepper-font:
-  600 1.40625rem/124.44444444444444% 'Lato',
-  sans-serif;
+$gcds-stepper-font: 600 1.40625rem/124.44444444444444% "Lato", sans-serif;
 $gcds-stepper-margin: 0 0 1.125rem;
 $gcds-stepper-text: #43474e;
 $gcds-textarea-border-radius: 0.1875rem;
@@ -900,9 +758,7 @@ $gcds-textarea-disabled-background: #d6d9dd;
 $gcds-textarea-disabled-text: #545961;
 $gcds-textarea-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-textarea-focus-text: #0535d2;
-$gcds-textarea-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-textarea-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-textarea-margin: 0 0 1.5rem;
 $gcds-textarea-min-height: 3rem;
 $gcds-textarea-outline-width: 0.1875rem;
@@ -915,9 +771,7 @@ $gcds-topic-menu-button-border: #26374a;
 $gcds-topic-menu-button-expanded-background: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-border-color: #444; // Colour mandated by policy
 $gcds-topic-menu-button-expanded-text: #ffffff;
-$gcds-topic-menu-button-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-button-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-button-home-background: #ffffff;
 $gcds-topic-menu-button-home-border-color: #ffffff;
 $gcds-topic-menu-button-home-text: #284162; // Colour mandated by policy: link colour
@@ -929,17 +783,13 @@ $gcds-topic-menu-focus-border-radius: 0.1875rem;
 $gcds-topic-menu-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-topic-menu-focus-outline-offset: 0.125rem;
 $gcds-topic-menu-focus-outline: 0.1875rem solid #0535d2;
-$gcds-topic-menu-font:
-  400 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-font: 400 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-max-width: 71.25rem;
 $gcds-topic-menu-menuitem-border-block-end: #545961;
 $gcds-topic-menu-menuitem-border-inline-end: #ffffff;
 $gcds-topic-menu-menuitem-expanded-background: #ffffff;
 $gcds-topic-menu-menuitem-expanded-text: #333333;
-$gcds-topic-menu-menuitem-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-menuitem-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-menuitem-padding: 0.9375rem 1.5rem;
 $gcds-topic-menu-menuitem-text: #ffffff;
 $gcds-topic-menu-menuitem-text-underline-offset: 0.25rem;
@@ -958,14 +808,10 @@ $gcds-topic-menu-mobile-topiclist-item-first-menuitem-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-hover-text: #000000;
 $gcds-topic-menu-mobile-topiclist-item-last-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-mobile-topiclist-menuitem-border-block-end: #d6d9dd;
-$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mobile-topiclist-menuitem-haspopup-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mobile-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-mobile-topiclist-menuitem-padding: 0.9375rem 1.5rem 0.9375rem 0;
-$gcds-topic-menu-mostrequested-item-first-font:
-  400 1.1111111111111112rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-mostrequested-item-first-font: 400 1.1111111111111112rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-mostrequested-item-last-margin-block-start: 0.9375rem;
 $gcds-topic-menu-mostrequested-item-width: 100%;
 $gcds-topic-menu-themelist-background: #444; // Colour mandated by policy
@@ -974,11 +820,8 @@ $gcds-topic-menu-themelist-text: #ffffff;
 $gcds-topic-menu-themelist-width: 100%;
 $gcds-topic-menu-topiclist-background: #ffffff;
 $gcds-topic-menu-topiclist-border: #d6d9dd;
-$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem
-  rgba(0, 0, 0, 0.1);
-$gcds-topic-menu-topiclist-item-first-font:
-  700 2.00225830078125rem/124.85901539399482% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-box-shadow: 0.5625rem 0.5625rem 0.5625rem 0.375rem rgba(0,0,0,.1);
+$gcds-topic-menu-topiclist-item-first-font: 700 2.00225830078125rem/124.85901539399482% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-item-first-margin-block-end: 2.25rem;
 $gcds-topic-menu-topiclist-item-first-width: 100%;
 $gcds-topic-menu-topiclist-item-last-left: 25rem;
@@ -988,16 +831,14 @@ $gcds-topic-menu-topiclist-margin-block-end: 1.5rem;
 $gcds-topic-menu-topiclist-menuitem-hover-text: #0535d2;
 $gcds-topic-menu-topiclist-menuitem-hover-text-decoration-thickness: 0.125rem;
 $gcds-topic-menu-topiclist-menuitem-padding: 0.375rem 0;
-$gcds-topic-menu-topiclist-menuitem-popup-font:
-  700 1.25rem/120% 'Noto Sans',
-  sans-serif;
+$gcds-topic-menu-topiclist-menuitem-popup-font: 700 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-topic-menu-topiclist-menuitem-popup-text: #000000;
 $gcds-topic-menu-topiclist-menuitem-text: #284162; // Colour mandated by policy: link colour
 $gcds-topic-menu-topiclist-min-height: 49.1825rem;
 $gcds-topic-menu-topiclist-padding: 0 2.25rem 1.5rem 2.25rem;
 $gcds-topic-menu-topiclist-text: #000000;
 $gcds-topic-menu-topiclist-width: calc(100% - 22.5rem);
-$gcds-verify-banner-background: #d6d9dd;
+$gcds-verify-banner-background: #f1f2f3;
 $gcds-verify-banner-container-xs: 20rem;
 $gcds-verify-banner-container-sm: 30rem;
 $gcds-verify-banner-container-md: 48rem;
@@ -1012,9 +853,7 @@ $gcds-verify-banner-content-list-margin: 0 0 1.5rem;
 $gcds-verify-banner-content-list-svg-margin: 0.1875rem;
 $gcds-verify-banner-content-padding-block-start: 1.5rem;
 $gcds-verify-banner-content-padding-block-end: 0.75rem;
-$gcds-verify-banner-font:
-  400 1.1111111111111112rem/135% 'Noto Sans',
-  sans-serif;
+$gcds-verify-banner-font: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-verify-banner-summary-padding: 0.75rem;
 $gcds-verify-banner-summary-content-margin: 0 1.125rem 0 0;
 $gcds-verify-banner-text: #333333;

--- a/tokens/components/alert/tokens.json
+++ b/tokens/components/alert/tokens.json
@@ -19,7 +19,7 @@
       },
       "default": {
         "background": {
-          "value": "{color.grayscale.0.value}",
+          "value": "{bg.white.value}",
           "type": "color"
         },
         "text": {

--- a/tokens/components/button/tokens.json
+++ b/tokens/components/button/tokens.json
@@ -44,7 +44,7 @@
     "primary": {
       "default": {
         "background": {
-          "value": "{color.blue.900.value}",
+          "value": "{bg.primary.value}",
           "type": "color"
         },
         "text": {

--- a/tokens/components/card/tokens.json
+++ b/tokens/components/card/tokens.json
@@ -1,7 +1,7 @@
 {
   "card": {
     "backgroundColor": {
-      "value": "{color.grayscale.0.value}",
+      "value": "{bg.white.value}",
       "type": "color"
     },
     "border": {
@@ -50,7 +50,7 @@
     },
     "hover": {
       "backgroundColor": {
-        "value": "{color.grayscale.50.value}",
+        "value": "{bg.light.value}",
         "type": "color"
       },
       "boxShadow": {

--- a/tokens/components/checkbox/tokens.json
+++ b/tokens/components/checkbox/tokens.json
@@ -58,7 +58,7 @@
     },
     "focus": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "box-shadow": {

--- a/tokens/components/file-uploader/tokens.json
+++ b/tokens/components/file-uploader/tokens.json
@@ -2,7 +2,7 @@
   "file-uploader": {
     "button": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "border": {

--- a/tokens/components/footer/tokens.json
+++ b/tokens/components/footer/tokens.json
@@ -51,7 +51,7 @@
     },
     "main": {
       "background": {
-        "value": "{color.blue.900.value}",
+        "value": "{bg.primary.value}",
         "type": "color"
       },
       "govnav": {
@@ -93,7 +93,7 @@
     },
     "sub": {
       "background": {
-        "value": "{color.grayscale.50.value}",
+        "value": "{bg.light.value}",
         "type": "color"
       },
       "gridGap": {

--- a/tokens/components/input/tokens.json
+++ b/tokens/components/input/tokens.json
@@ -18,7 +18,7 @@
     },
     "default": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "text": {

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -2,7 +2,7 @@
   "nav-group": {
     "mobile": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "list": {
@@ -50,7 +50,7 @@
         },
         "hover": {
           "background": {
-            "value": "{color.grayscale.50.value}",
+            "value": "{bg.light.value}",
             "type": "color"
           }
         },
@@ -69,7 +69,7 @@
     "topNav": {
       "dropdown": {
         "background": {
-          "value": "{color.grayscale.50.value}",
+          "value": "{bg.light.value}",
           "type": "color"
         },
         "box-shadow": {
@@ -94,7 +94,7 @@
         },
         "hover": {
           "background": {
-            "value": "{color.grayscale.100.value}",
+            "value": "{disabled.background.value}",
             "type": "color"
           },
           "text": {
@@ -126,7 +126,7 @@
         },
         "expanded": {
           "background-color": {
-            "value": "{color.grayscale.100.value}",
+            "value": "{disabled.background.value}",
             "type": "color"
           }
         },

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -94,7 +94,7 @@
         },
         "hover": {
           "background": {
-            "value": "{disabled.background.value}",
+            "value": "{color.grayscale.100.value}",
             "type": "color"
           },
           "text": {
@@ -126,7 +126,7 @@
         },
         "expanded": {
           "background-color": {
-            "value": "{disabled.background.value}",
+            "value": "{color.grayscale.100.value}",
             "type": "color"
           }
         },

--- a/tokens/components/nav-link/tokens.json
+++ b/tokens/components/nav-link/tokens.json
@@ -118,7 +118,7 @@
     "topNav": {
       "hover": {
         "background": {
-          "value": "{disabled.background.value}",
+          "value": "{color.grayscale.100.value}",
           "type": "color"
         }
       },

--- a/tokens/components/nav-link/tokens.json
+++ b/tokens/components/nav-link/tokens.json
@@ -106,7 +106,7 @@
     "sideNav": {
       "hover": {
         "background": {
-          "value": "{color.grayscale.50.value}",
+          "value": "{bg.light.value}",
           "type": "color"
         }
       },
@@ -118,7 +118,7 @@
     "topNav": {
       "hover": {
         "background": {
-          "value": "{color.grayscale.100.value}",
+          "value": "{disabled.background.value}",
           "type": "color"
         }
       },

--- a/tokens/components/pagination/tokens.json
+++ b/tokens/components/pagination/tokens.json
@@ -6,7 +6,7 @@
         "type": "color"
       },
       "background": {
-        "value": "{color.blue.900.value}",
+        "value": "{bg.primary.value}",
         "type": "color"
       }
     },

--- a/tokens/components/phase-banner/tokens.json
+++ b/tokens/components/phase-banner/tokens.json
@@ -31,7 +31,7 @@
     },
     "primary": {
       "background": {
-        "value": "{color.blue.900.value}",
+        "value": "{bg.primary.value}",
         "type": "color"
       },
       "text": {
@@ -41,7 +41,7 @@
     },
     "secondary": {
       "background": {
-        "value": "{color.grayscale.100.value}",
+        "value": "{bg.light.value}",
         "type": "color"
       },
       "text": {

--- a/tokens/components/radio/tokens.json
+++ b/tokens/components/radio/tokens.json
@@ -54,7 +54,7 @@
     },
     "focus": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "box-shadow": {

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -12,7 +12,7 @@
     },
     "default": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "text": {

--- a/tokens/components/select/tokens.json
+++ b/tokens/components/select/tokens.json
@@ -24,7 +24,7 @@
     },
     "default": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "text": {

--- a/tokens/components/textarea/tokens.json
+++ b/tokens/components/textarea/tokens.json
@@ -18,7 +18,7 @@
     },
     "default": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "text": {

--- a/tokens/components/top-nav/tokens.json
+++ b/tokens/components/top-nav/tokens.json
@@ -1,7 +1,7 @@
 {
   "top-nav": {
     "background": {
-      "value": "{color.grayscale.50.value}",
+      "value": "{bg.light.value}",
       "type": "color"
     },
     "maxWidth": {

--- a/tokens/components/topic-menu/tokens.json
+++ b/tokens/components/topic-menu/tokens.json
@@ -163,13 +163,13 @@
       },
       "menuitem": {
         "background": {
-          "value": "{disabled.background.value}",
+          "value": "{color.grayscale.100.value}",
           "type": "color"
         }
       },
       "mostrequested": {
         "background": {
-          "value": "{disabled.background.value}",
+          "value": "{color.grayscale.100.value}",
           "type": "color"
         },
         "border": {

--- a/tokens/components/topic-menu/tokens.json
+++ b/tokens/components/topic-menu/tokens.json
@@ -6,7 +6,7 @@
     },
     "button": {
       "background": {
-        "value": "{color.blue.900.value}",
+        "value": "{bg.primary.value}",
         "type": "color"
       },
       "border": {
@@ -40,7 +40,7 @@
       },
       "home": {
         "background": {
-          "value": "{color.grayscale.0.value}",
+          "value": "{bg.white.value}",
           "type": "color"
         },
         "borderColor": {
@@ -114,7 +114,7 @@
       },
       "expanded": {
         "background": {
-          "value": "{color.grayscale.0.value}",
+          "value": "{bg.white.value}",
           "type": "color"
         },
         "text": {
@@ -163,13 +163,13 @@
       },
       "menuitem": {
         "background": {
-          "value": "{color.grayscale.100.value}",
+          "value": "{disabled.background.value}",
           "type": "color"
         }
       },
       "mostrequested": {
         "background": {
-          "value": "{color.grayscale.100.value}",
+          "value": "{disabled.background.value}",
           "type": "color"
         },
         "border": {
@@ -302,7 +302,7 @@
     },
     "topiclist": {
       "background": {
-        "value": "{color.grayscale.0.value}",
+        "value": "{bg.white.value}",
         "type": "color"
       },
       "border": {

--- a/tokens/components/verify-banner/tokens.json
+++ b/tokens/components/verify-banner/tokens.json
@@ -1,7 +1,7 @@
 {
   "verify-banner": {
     "background": {
-      "value": "{color.grayscale.100.value}",
+      "value": "{bg.light.value}",
       "type": "color"
     },
     "container": {

--- a/tokens/global/color/tokens.json
+++ b/tokens/global/color/tokens.json
@@ -11,6 +11,33 @@
       "comment": "Global color: active text"
     }
   },
+  "bg": {
+    "black": {
+      "value": "{color.grayscale.1000.value}",
+      "type": "color",
+      "comment": "Global bg color: black background"
+    },
+    "dark": {
+      "value": "{color.grayscale.900.value}",
+      "type": "color",
+      "comment": "Global bg color: dark background"
+    },
+    "light": {
+      "value": "{color.grayscale.50.value}",
+      "type": "color",
+      "comment": "Global bg color: light background"
+    },
+    "primary": {
+      "value": "{color.blue.900.value}",
+      "type": "color",
+      "comment": "Global bg color: primary background"
+    },
+    "white": {
+      "value": "{color.grayscale.0.value}",
+      "type": "color",
+      "comment": "Global bg color: white background"
+    }
+  },
   "border": {
     "default": {
       "value": "{color.grayscale.500.value}",


### PR DESCRIPTION
# Summary | Résumé

Create global background tokens and integrate them into existing component tokens.

Note: I updated the value for the phase-banner and verify-banner background tokens to use the light bg colour instead of the disabled background color to match our other header elements.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/728)