### PR TITLE
chore: update changelog (remove chores + add dates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,6 @@ All notable changes to this project will be documented in this file.
 
 ## [1.11.1](https://github.com/cds-snc/gcds-tokens/compare/gcds-tokens-v1.11.0...gcds-tokens-v1.11.1) (2024-02-20)
 
-### Documentation
-
-- add french translations for changelog ([#219](https://github.com/cds-snc/gcds-tokens/issues/219)) ([6aa9d24](https://github.com/cds-snc/gcds-tokens/commit/6aa9d24e03f7fc45457cf4cc30a61388ad49be99))
-
 ### Code Refactoring
 
 - remove text-only tokens from button component ([#199](https://github.com/cds-snc/gcds-tokens/issues/199)) ([0764dff](https://github.com/cds-snc/gcds-tokens/commit/0764dff00bd7d5f68e8b005829988fb800df29a3))
@@ -45,9 +41,6 @@ All notable changes to this project will be documented in this file.
 - add focus box-shadow to link token ([#192](https://github.com/cds-snc/gcds-tokens/issues/192)) ([ca00a31](https://github.com/cds-snc/gcds-tokens/commit/ca00a310ca726156c94f61944d432c1275a2bb19))
 - update link tokens ([#191](https://github.com/cds-snc/gcds-tokens/issues/191)) ([3649eb8](https://github.com/cds-snc/gcds-tokens/commit/3649eb833fadaee0024c4e183942f96fa524a786))
 - remove link token focus-border-color ([#198](https://github.com/cds-snc/gcds-tokens/issues/198)) ([0e17bf1](https://github.com/cds-snc/gcds-tokens/commit/0e17bf1ef16960e5086949f940c2fa05fb2675a5))
-- give `npm publish` time to complete ([#189](https://github.com/cds-snc/gcds-tokens/issues/189)) ([2afddba](https://github.com/cds-snc/gcds-tokens/commit/2afddba1804e53cc31d6c0e638e089474ad9a24b))
-- **deps:** update all non-major github action dependencies ([#193](https://github.com/cds-snc/gcds-tokens/issues/193)) ([b70d681](https://github.com/cds-snc/gcds-tokens/commit/b70d681a9e00e15fb79db67a28ee3993064e476d))
-- synced local '.github/workflows/backstage-catalog-helper.yml' with remote 'tools/sre_file_sync/backstage-catalog-helper.yml' ([#196](https://github.com/cds-snc/gcds-tokens/issues/196)) ([0f10d01](https://github.com/cds-snc/gcds-tokens/commit/0f10d01d10b6084bdcd8b5af6c0cefe1793549e4))
 
 ## [1.10.0](https://github.com/cds-snc/gcds-tokens/compare/gcds-tokens-v1.9.2...gcds-tokens-v1.10.0) (2023-11-01)
 
@@ -58,12 +51,6 @@ All notable changes to this project will be documented in this file.
 ### Miscellaneous Chores
 
 - add new token for link (underline offset) ([#185](https://github.com/cds-snc/gcds-tokens/issues/185)) ([75c8769](https://github.com/cds-snc/gcds-tokens/commit/75c87693d55f41b2d30cb10eaee529e4e8e5e1f6))
-- bootstrap releases for path: . ([#186](https://github.com/cds-snc/gcds-tokens/issues/186)) ([19d7074](https://github.com/cds-snc/gcds-tokens/commit/19d70749058be700009c2eb5071796e6b3d569b8))
-- created local '.github/workflows/backstage-catalog-helper.yml' from remote 'tools/sre_file_sync/backstage-catalog-helper.yml' ([#182](https://github.com/cds-snc/gcds-tokens/issues/182)) ([ce3fd35](https://github.com/cds-snc/gcds-tokens/commit/ce3fd35354945d58a6782084861e935cb477df03))
-- **deps:** lock file maintenance ([#188](https://github.com/cds-snc/gcds-tokens/issues/188)) ([0c0f69e](https://github.com/cds-snc/gcds-tokens/commit/0c0f69ed62dad4bac481750c5b25ddfd4e109ec4))
-- **deps:** update all non-major github action dependencies ([#181](https://github.com/cds-snc/gcds-tokens/issues/181)) ([fedb4c2](https://github.com/cds-snc/gcds-tokens/commit/fedb4c24ee511d627eadc336f74e77374480d0ad))
-- synced local '.github/workflows/backstage-catalog-helper.yml' with remote 'tools/sre_file_sync/backstage-catalog-helper.yml' ([#183](https://github.com/cds-snc/gcds-tokens/issues/183)) ([66d48cd](https://github.com/cds-snc/gcds-tokens/commit/66d48cd16e83cbd119a84175ab099e754b555900))
-- synced local '.github/workflows/backstage-catalog-helper.yml' with remote 'tools/sre_file_sync/backstage-catalog-helper.yml' ([#184](https://github.com/cds-snc/gcds-tokens/issues/184)) ([9d8a374](https://github.com/cds-snc/gcds-tokens/commit/9d8a3746c8148143d03c8b495abf71095acd380d))
 
 ## v1.9.2
 
@@ -330,10 +317,6 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 
 ## [1.11.1](https://github.com/cds-snc/gcds-tokens/compare/gcds-tokens-v1.11.0...gcds-tokens-v1.11.1) (2024-02-20)
 
-### Documentation
-
-- ajout des traductions françaises pour le journal des modifications ([\#219](https://github.com/cds-snc/gcds-tokens/issues/219)) ([6aa9d24](https://github.com/cds-snc/gcds-tokens/commit/6aa9d24e03f7fc45457cf4cc30a61388ad49be99))
-
 ### Refactorisation du code
 
 - suppression des unités de style textuels du composant bouton ([\#199](https://github.com/cds-snc/gcds-tokens/issues/199)) ([0764dff](https://github.com/cds-snc/gcds-tokens/commit/0764dff00bd7d5f68e8b005829988fb800df29a3))
@@ -351,9 +334,6 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - ajout de l’élément box-shadow du jeton de lien ([\#192](https://github.com/cds-snc/gcds-tokens/issues/192)) ([ca00a31](https://github.com/cds-snc/gcds-tokens/commit/ca00a310ca726156c94f61944d432c1275a2bb19))
 - mise à jour des jetons de lien (#[191](https://github.com/cds-snc/gcds-tokens/issues/191)) ([3649eb8](https://github.com/cds-snc/gcds-tokens/commit/3649eb833fadaee0024c4e183942f96fa524a786))
 - suppression de l’élément focus-border-color du jeton de lien ([\#198](https://github.com/cds-snc/gcds-tokens/issues/198)) ([0e17bf1](https://github.com/cds-snc/gcds-tokens/commit/0e17bf1ef16960e5086949f940c2fa05fb2675a5))
-- fonction `npm publish` exécutée ([\#189](https://github.com/cds-snc/gcds-tokens/issues/189)) ([2afddba](https://github.com/cds-snc/gcds-tokens/commit/2afddba1804e53cc31d6c0e638e089474ad9a24b))
-- **dépendances :** mise à jour de toute dépendance d’action github non majeure ([\#193](https://github.com/cds-snc/gcds-tokens/issues/193)) ([b70d681](https://github.com/cds-snc/gcds-tokens/commit/b70d681a9e00e15fb79db67a28ee3993064e476d))
-- synchronisation du fichier local '.github/workflows/backstage-catalog-helper.yml' avec le fichier en réseau 'tools/sre_file_sync/backstage-catalog-helper.yml' ([\#196](https://github.com/cds-snc/gcds-tokens/issues/196)) ([0f10d01](https://github.com/cds-snc/gcds-tokens/commit/0f10d01d10b6084bdcd8b5af6c0cefe1793549e4))
 
 ## [1.10.0](https://github.com/cds-snc/gcds-tokens/compare/gcds-tokens-v1.9.2...gcds-tokens-v1.10.0) (2023-11-01)
 
@@ -364,12 +344,6 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 ### Tâches diverses
 
 - ajout d’un nouveau jeton de lien (décalage de soulignement) ([\#185](https://github.com/cds-snc/gcds-tokens/issues/185)) ([75c8769](https://github.com/cds-snc/gcds-tokens/commit/75c87693d55f41b2d30cb10eaee529e4e8e5e1f6))
-- versions bootstrap pour le chemin d’accès : . ([\#186](https://github.com/cds-snc/gcds-tokens/issues/186)) ([19d7074](https://github.com/cds-snc/gcds-tokens/commit/19d70749058be700009c2eb5071796e6b3d569b8))
-- création du fichier local '.github/workflows/backstage-catalog-helper.yml' à l’aide du fichier en réseau 'tools/sre_file_sync/backstage-catalog-helper.yml' ([\#182](https://github.com/cds-snc/gcds-tokens/issues/182)) ([ce3fd35](https://github.com/cds-snc/gcds-tokens/commit/ce3fd35354945d58a6782084861e935cb477df03))
-- **dépendances :** maintenance des fichiers de verrouillage ([\#188](https://github.com/cds-snc/gcds-tokens/issues/188)) ([0c0f69e](https://github.com/cds-snc/gcds-tokens/commit/0c0f69ed62dad4bac481750c5b25ddfd4e109ec4))
-- **dépendances :** mise à jour de toute dépendance d’action github non majeure ([\#181](https://github.com/cds-snc/gcds-tokens/issues/181)) ([fedb4c2](https://github.com/cds-snc/gcds-tokens/commit/fedb4c24ee511d627eadc336f74e77374480d0ad))
-- synchronisation du fichier local '.github/workflows/backstage-catalog-helper.yml' avec le fichier en réseau 'tools/sre_file_sync/backstage-catalog-helper.yml' ([\#183](https://github.com/cds-snc/gcds-tokens/issues/183)) ([66d48cd](https://github.com/cds-snc/gcds-tokens/commit/66d48cd16e83cbd119a84175ab099e754b555900))
-- synchronisation du fichier local '.github/workflows/backstage-catalog-helper.yml' avec le fichier en réseau 'tools/sre_file_sync/backstage-catalog-helper.yml' ([\#184](https://github.com/cds-snc/gcds-tokens/issues/184)) ([9d8a374](https://github.com/cds-snc/gcds-tokens/commit/9d8a3746c8148143d03c8b495abf71095acd380d))
 
 ## v1.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,19 +52,19 @@ All notable changes to this project will be documented in this file.
 
 - add new token for link (underline offset) ([#185](https://github.com/cds-snc/gcds-tokens/issues/185)) ([75c8769](https://github.com/cds-snc/gcds-tokens/commit/75c87693d55f41b2d30cb10eaee529e4e8e5e1f6))
 
-## v1.9.2
+## 1.9.2 (2023-10-26)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/177 - [479ca70](https://github.com/cds-snc/gcds-tokens/commit/479ca70d56be13f6e453f2a309d35de515cc7bb8) - Add focus box-shadow to multiple components.
 
-## v1.9.1
+## 1.9.1 (2023-10-25)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/178 - [9130ec3](https://github.com/cds-snc/gcds-tokens/commit/9130ec37e7114256e40c4fce497dad2bdaf0aefd) - Adds updates for gcds-link tokens.
 
-## v1.9.0
+## 1.9.0 (2023-10-19)
 
 ### Minor
 
@@ -74,33 +74,33 @@ All notable changes to this project will be documented in this file.
 
 - https://github.com/cds-snc/gcds-tokens/pull/175 - [03639c3](https://github.com/cds-snc/gcds-tokens/pull/175/commits/03639c3bfaafcfbaae36f21288a58fdd870755eb) - Add character limit tokens for gcds-heading.
 
-## v1.8.0
+## 1.8.0 (2023-10-16)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/173 - [4a20f0b](https://github.com/cds-snc/gcds-tokens/pull/173/commits/4a20f0b55ef0679b1b73fa486bc21cf87fcadb07) - Add gcds-link tokens.
 
-## v1.7.0
+## 1.7.0 (2023-10-10)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/170 - [aec4aa5](https://github.com/cds-snc/gcds-tokens/pull/170/commits/aec4aa5d5c34fb339c321a17880572b82e444461) - Add mobile font styles.
 - https://github.com/cds-snc/gcds-tokens/pull/170 - [edd8c9e](https://github.com/cds-snc/gcds-tokens/pull/170/commits/edd8c9ecaf4f925ab0446b0dda6570b0fba438d5) - Add gcds-heading tokens.
 
-## v1.6.1
+## 1.6.1 (2023-08-31)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/150 - [aea2914](https://github.com/cds-snc/gcds-tokens/pull/150/commits/aea2914cd537f111849ec922eefb0544b1d154a0) - Details a11y update.
 
-## v1.6.0
+## 1.6.0 (2023-08-23)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/145 - [4a8b152](https://github.com/cds-snc/gcds-tokens/pull/145/commits/4a8b15275a2cdc17e41eb03e9c3f16ba7b1a4120) - Add component tokens for gcds-topic-menu.
 - https://github.com/cds-snc/gcds-tokens/pull/145 - [63b6db3](https://github.com/cds-snc/gcds-tokens/pull/145/commits/63b6db3a21d56a437f2d32ca31d483e294561b69) - Update border tokens + add missing border tokens.
 
-## v1.5.5
+## 1.5.5 (2023-08-23)
 
 ### Patch
 
@@ -108,37 +108,37 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/146 - [6179815](https://github.com/cds-snc/gcds-tokens/pull/146/commits/617981581b7263275fbb5175db4ac880f1fd6930) - Change top nav home link font weight to semibold.
 - https://github.com/cds-snc/gcds-tokens/pull/146 - [90d9c7e](https://github.com/cds-snc/gcds-tokens/pull/146/commits/90d9c7e11f5dea7ced89885bb334aa761e90d050) - Rename header topnav slot to skip-to-nav.
 
-## v1.5.4
+## 1.5.4 (2023-08-16)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/144 - [160740c](https://github.com/cds-snc/gcds-tokens/pull/144/commits/160740c29f7ba4c3d1683013b245b8b39d8bbf2c) - Token update for changes from token review.
 
-## v1.5.3
+## 1.5.3 (2023-08-10)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/142 - [cd9a43c](https://github.com/cds-snc/gcds-tokens/pull/142/commits/cd9a43c3a3c893b4843d785fbc43997c8afc491e) - Topnav fixes.
 
-## v1.5.2
+## 1.5.2 (2023-08-04)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/140 - [be78635](https://github.com/cds-snc/gcds-tokens/pull/140/commits/be78635f25237de39577a40c81af420fd452faac) - Change border-radius tokens in search component.
 
-## v1.5.1
+## 1.5.1 (2023-08-03)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/139 - [6cc2d8c](https://github.com/cds-snc/gcds-tokens/pull/139/commits/6cc2d8cde5529254c65871f51832c1ab9abe2878) - Remove unused width token from header.
 
-## v1.5.0
+## 1.5.0 (2023-08-02)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/138 - [24a53ab](https://github.com/cds-snc/gcds-tokens/pull/138/commits/24a53abfe2d42bff6cdd3514d0edd1fb8f253708) - Add gcds-search component tokens.
 
-## v1.4.2
+## 1.4.2 (2023-07-24)
 
 ### Patch
 
@@ -146,13 +146,13 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/136 - [5732ad1](https://github.com/cds-snc/gcds-tokens/pull/136/commits/5732ad112ec366ac6ac533e968aa6f1ea5d24521) - Update error state styling for form components.
 - https://github.com/cds-snc/gcds-tokens/pull/136 - [0966931](https://github.com/cds-snc/gcds-tokens/pull/136/commits/0966931be61b094cdc0449630009df50568babf5) - Remove subheading tokens from error summary.
 
-## v1.4.1
+## 1.4.1 (2023-07-10)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/134 - [204bd2b](https://github.com/cds-snc/gcds-tokens/pull/134/commits/204bd2b856c7fb235b6aee5f5148dcf3e95e4dbf) - Add border token for container component.
 
-## v1.4.0
+## 1.4.0 (2023-07-04)
 
 ### Minor
 
@@ -170,51 +170,51 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/131 - [fcadc41](https://github.com/cds-snc/gcds-tokens/pull/131/commits/fcadc4143df8c217cbc40b9f092abfc100151708) - Update container sizes xl and lg.
 - https://github.com/cds-snc/gcds-tokens/pull/131 - [41cb127](https://github.com/cds-snc/gcds-tokens/pull/131/commits/41cb12720c08e2a4c41777de5a06d29367cc7a8f) - Remove site menu tokens.
 
-## v1.3.3
+## 1.3.3 (2023-07-04)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/133 - [76f0a75](https://github.com/cds-snc/gcds-tokens/pull/133/commits/76f0a7566a06d3423ca9e7928e87241a6a31fdc3) - Update card border tokens.
 
-## v1.3.2
+## 1.3.2 (2023-06-29)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/132 - [2e82963](https://github.com/cds-snc/gcds-tokens/pull/132/commits/2e829637bc7247bf3bc42e1e4852ad28cc7b2485) - Add container component tokens.
 
-## v1.3.1
+## 1.3.1 (2023-06-27)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/130 - [de8074b](https://github.com/cds-snc/gcds-tokens/pull/130/commits/de8074b826f2a9a61f5f0ed98052102f0524b1ee) - Add missing description token for card.
 
-## v1.3.0
+## 1.3.0 (2023-06-26)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/127 - [82832a8](https://github.com/cds-snc/gcds-tokens/pull/127/commits/82832a87119f871687edd63f39ea16f8e34353cc) - New tokens for gcds-card.
 - https://github.com/cds-snc/gcds-tokens/pull/127 - [26d1ee8](https://github.com/cds-snc/gcds-tokens/pull/127/commits/26d1ee89c6c0842e42fcdcf1b8b01eaffb406abe) - Update card border token.
 
-## v1.2.1
+## 1.2.1 (2023-06-22)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/128 - [3e72118](https://github.com/cds-snc/gcds-tokens/pull/128/commits/3e721187a5b1dda1637fe71443a5a0e82d901a0a) - Add missing component tokens.
 
-## v1.2.0
+## 1.2.0 (2023-06-21)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/126 - [a76688c](https://github.com/cds-snc/gcds-tokens/pull/126/commits/a76688c0ed9aa507f90a04268d7123d673e3fcbd) - Rename base.json and base.js files to tokens.json and tokens.js to improve consistency.
 - https://github.com/cds-snc/gcds-tokens/pull/126 - [4f4ff47](https://github.com/cds-snc/gcds-tokens/pull/126/commits/4f4ff477ef4090fb694a740c534bc423dff1750f) - Change token path to create output files for each token category.
 
-## v1.1.3
+## 1.1.3 (2023-06-05)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/124 - [8c2aff2](https://github.com/cds-snc/gcds-tokens/pull/124/commits/8c2aff2c03db5d3f7aa08ae0271f71a3d7a8fc74) - Remove alert active border + pagination border tokens.
 
-## v1.1.2
+## 1.1.2 (2023-05-31)
 
 ### Minor
 
@@ -231,32 +231,32 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/122 - [5098a50](https://github.com/cds-snc/gcds-tokens/pull/122/commits/5098a50df78c5a13e71e38cb9c33f39d852130eb) - Ensure canada signature uses black text.
 - https://github.com/cds-snc/gcds-tokens/pull/122 - [4d42cc5](https://github.com/cds-snc/gcds-tokens/pull/122/commits/4d42cc5a1d4b6f40f5ee258ed15edc41552295e6) - Reorganize blue colour tokens from light to dark.
 
-## v1.1.1
+## 1.1.1 (2023-04-25)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/114 - [8fc59ab](https://github.com/cds-snc/gcds-tokens/pull/114/commits/8fc59ab3c488c4f912e5b7d93a8a4248f8e6fbf7) - Add new margin + padding tokens for gcds-breadcrumbs.
 
-## v1.1.0
+## 1.1.0 (2023-04-21)
 
 ### Minor
 
 - https://github.com/cds-snc/gcds-tokens/pull/112 - [42956e2](https://github.com/cds-snc/gcds-tokens/pull/112/commits/42956e2e1475ab5257c14cb7583f36f3312a71ff) - Add error summary component.
 - https://github.com/cds-snc/gcds-tokens/pull/112 - [0ac7a26](https://github.com/cds-snc/gcds-tokens/pull/112/commits/0ac7a26669217ed37d5fb48bafc30da4c2b5ad81) - Add text color token.
 
-## v1.0.6
+## 1.0.6 (2023-04-21)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/113 - [a9b2712](https://github.com/cds-snc/gcds-tokens/pull/113/commits/a9b27127dc4cb47d51ed881d0dd2c6665b676802) - Adjust lang-toggle tokens.
 
-## v1.0.5
+## 1.0.5 (2023-03-30)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/111 - [bf64968](https://github.com/cds-snc/gcds-tokens/pull/111/commits/bf6496851ff3352e85663d58e69d81b711ac693b) - New tokes for breadcrumbs and details components.
 
-## v1.0.4
+## 1.0.4 (2023-03-27)
 
 ### Patch
 
@@ -264,13 +264,13 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/96 - [a733313](https://github.com/cds-snc/gcds-tokens/pull/96/commits/a733313f23590fa784bdeebf5e76771f221636fd) - Footer link color updates.
 - https://github.com/cds-snc/gcds-tokens/pull/106 - [6db5164](https://github.com/cds-snc/gcds-tokens/pull/106/commits/6db5164684226eac930e5d76633e07533a157aea) - Add tokens to support mobile full-width buttons.
 
-## v1.0.3
+## 1.0.3 (2023-03-09)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/93 - [ad9a291](https://github.com/cds-snc/gcds-tokens/pull/93/commits/ad9a2915571230b2a278a5f42400a77a33f7f1e6) - Update sub-menu colour to lighter colour.
 
-## v1.0.2
+## 1.0.2 (2023-03-01)
 
 ### Patch
 
@@ -278,14 +278,14 @@ All notable changes to this project will be documented in this file.
 - https://github.com/cds-snc/gcds-tokens/pull/92 - [8806b49](https://github.com/cds-snc/gcds-tokens/pull/92/commits/8806b494d3933d9836a8bc86eb237caafe4fddcd) - Add new text secondary colour.
 - https://github.com/cds-snc/gcds-tokens/pull/92 - [99da08f](https://github.com/cds-snc/gcds-tokens/pull/92/commits/99da08f1619841e2f11c1bc2b995a4607809ea6d) - Update disabled text colour for better colour contrast.
 
-## v1.0.1
+## 1.0.1 (2023-02-22)
 
 ### Patch
 
 - https://github.com/cds-snc/gcds-tokens/pull/90 - [48efe65](https://github.com/cds-snc/gcds-tokens/pull/90/commits/48efe65acbe3d4f6f72d246b14f9748ee2c3b09f) - Design updates to button, label, file uploader, footer.
 - https://github.com/cds-snc/gcds-tokens/pull/90 - [7a9bc12](https://github.com/cds-snc/gcds-tokens/pull/90/commits/7a9bc126226c9653c1e20882ec1b5177fbd815b8) - Add tokens for button text only.
 
-## v1.0.0
+## 1.0.0 (2023-02-10)
 
 ### New features
 
@@ -345,19 +345,19 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 
 - ajout d’un nouveau jeton de lien (décalage de soulignement) ([\#185](https://github.com/cds-snc/gcds-tokens/issues/185)) ([75c8769](https://github.com/cds-snc/gcds-tokens/commit/75c87693d55f41b2d30cb10eaee529e4e8e5e1f6))
 
-## v1.9.2
+## 1.9.2 (2023-10-26)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/177 - [479ca70](https://github.com/cds-snc/gcds-tokens/commit/479ca70d56be13f6e453f2a309d35de515cc7bb8) \- Ajout de l’élément box-focus à plusieurs composants
 
-## v1.9.1
+## 1.9.1 (2023-10-25)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/178 - [9130ec3](https://github.com/cds-snc/gcds-tokens/commit/9130ec37e7114256e40c4fce497dad2bdaf0aefd) \- Ajout de mises à jour pour les jetons gcds-link
 
-## v1.9.0
+## 1.9.0 (2023-10-19)
 
 ### Changement mineur
 
@@ -367,33 +367,33 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 
 - https://github.com/cds-snc/gcds-utility/pull/175 - [1889762](https://github.com/cds-snc/gcds-tokens/pull/175/commits/03639c3bfaafcfbaae36f21288a58fdd870755eb) \- Ajout de jetons de limite de caractères pour gcds-heading
 
-## v1.8.0
+## 1.8.0 (2023-10-16)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/173 - [4a20f0b](https://github.com/cds-snc/gcds-tokens/pull/173/commits/4a20f0b55ef0679b1b73fa486bc21cf87fcadb07) \- Ajout de jetons pour gcds-link
 
-## v1.7.0
+## 1.7.0 (2023-10-10)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-utility/pull/170 - [aec4aa5](https://github.com/cds-snc/gcds-tokens/pull/170/commits/aec4aa5d5c34fb339c321a17880572b82e444461) \- Ajout de styles de police pour les appareils mobiles
 - https://github.com/cds-snc/gcds-tokens/pull/170 - [edd8c9e](https://github.com/cds-snc/gcds-tokens/pull/170/commits/edd8c9ecaf4f925ab0446b0dda6570b0fba438d5) \- Ajout de jetons pour gcds-heading
 
-## v1.6.1
+## 1.6.1 (2023-08-31)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-utility/pull/150 - [aea2914](https://github.com/cds-snc/gcds-tokens/pull/150/commits/aea2914cd537f111849ec922eefb0544b1d154a0) \- Mise à jour des détails sur l’accessibilité (a11y)
 
-## v1.6.0
+## 1.6.0 (2023-08-23)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/145 - [4a8b152](https://github.com/cds-snc/gcds-tokens/pull/145/commits/4a8b15275a2cdc17e41eb03e9c3f16ba7b1a4120) \- Ajout de jetons de composant pour gcds-topic-menu
 - https://github.com/cds-snc/gcds-tokens/pull/145 - [63b6db3](https://github.com/cds-snc/gcds-tokens/pull/145/commits/63b6db3a21d56a437f2d32ca31d483e294561b69) \- Mise à jour des jetons de bordure et ajout des jetons de bordure manquants
 
-## v1.5.5
+## 1.5.5 (2023-08-23)
 
 ### Correctif
 
@@ -401,37 +401,37 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-tokens/pull/146 - [6179815](https://github.com/cds-snc/gcds-tokens/pull/146/commits/617981581b7263275fbb5175db4ac880f1fd6930) \- Modification du poids de la police du lien d’accueil de la navigation supérieure en semi-gras
 - https://github.com/cds-snc/gcds-tokens/pull/146 - [90d9c7e](https://github.com/cds-snc/gcds-tokens/pull/146/commits/90d9c7e11f5dea7ced89885bb334aa761e90d050) \- Emplacement navigation supérieure (topnav) de l’en-tête renommé à skip-to-nav.
 
-## v1.5.4
+## 1.5.4 (2023-08-16)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/144 - [160740c](https://github.com/cds-snc/gcds-tokens/pull/144/commits/160740c29f7ba4c3d1683013b245b8b39d8bbf2c) \- Mise à jour des jetons pour refléter les changements apportés lors de la révision des jetons
 
-## v1.5.3
+## 1.5.3 (2023-08-10)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/142 - [cd9a43c](https://github.com/cds-snc/gcds-tokens/pull/142/commits/cd9a43c3a3c893b4843d785fbc43997c8afc491e) \- Correctifs de l’élément topnav
 
-## v1.5.2
+## 1.5.2 (2023-08-04)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/140 - [be78635](https://github.com/cds-snc/gcds-tokens/pull/140/commits/be78635f25237de39577a40c81af420fd452faac) \- Modification des jetons border-radius dans le composant recherche
 
-## v1.5.1
+## 1.5.1 (2023-08-03)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/139 - [6cc2d8c](https://github.com/cds-snc/gcds-tokens/pull/139/commits/6cc2d8cde5529254c65871f51832c1ab9abe2878) \- Suppression du jeton de largeur inutilisé de l’en-tête
 
-## v1.5.0
+## 1.5.0 (2023-08-02)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/138 - [24a53ab](https://github.com/cds-snc/gcds-tokens/pull/138/commits/24a53abfe2d42bff6cdd3514d0edd1fb8f253708) \- Ajout des jetons pour le composant gcds-search
 
-## v1.4.2
+## 1.4.2 (2023-07-24)
 
 ### Correctif
 
@@ -439,13 +439,13 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-tokens/pull/136 - [5732ad1](https://github.com/cds-snc/gcds-tokens/pull/136/commits/5732ad112ec366ac6ac533e968aa6f1ea5d24521) \- Mise à jour du style d’état d’erreur pour les composants de formulaire
 - https://github.com/cds-snc/gcds-tokens/pull/136 - [0966931](https://github.com/cds-snc/gcds-tokens/pull/136/commits/0966931be61b094cdc0449630009df50568babf5) \- Suppression des jetons de sous-titre du résumé des erreurs
 
-## v1.4.1
+## 1.4.1 (2023-07-10)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/134 - [204bd2b](https://github.com/cds-snc/gcds-tokens/pull/134/commits/204bd2b856c7fb235b6aee5f5148dcf3e95e4dbf) \- Ajout d’un jeton de bordure pour le composant conteneur
 
-## v1.4.0
+## 1.4.0 (2023-07-04)
 
 ### Changement mineur
 
@@ -463,51 +463,51 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-tokens/pull/131 - [fcadc41](https://github.com/cds-snc/gcds-tokens/pull/131/commits/fcadc4143df8c217cbc40b9f092abfc100151708) \- Mise à jour des tailles de contenants xl et lg
 - https://github.com/cds-snc/gcds-tokens/pull/131 - [4621154](https://github.com/cds-snc/gcds-tokens/pull/131/commits/41cb12720c08e2a4c41777de5a06d29367cc7a8f) \- Suppression des jetons site-menu
 
-## v1.3.3
+## 1.3.3 (2023-07-04)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/133 - [76f0a75](https://github.com/cds-snc/gcds-tokens/pull/133/commits/76f0a7566a06d3423ca9e7928e87241a6a31fdc3) \- Mise à jour des jetons de bordure de carte
 
-## v1.3.2
+## 1.3.2 (2023-06-29)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/132 - [2e82963](https://github.com/cds-snc/gcds-tokens/pull/132/commits/2e829637bc7247bf3bc42e1e4852ad28cc7b2485) \- Ajout des jetons pour le composant conteneur
 
-## v1.3.1
+## 1.3.1 (2023-06-27)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/130 - [de8074b](https://github.com/cds-snc/gcds-tokens/pull/130/commits/de8074b826f2a9a61f5f0ed98052102f0524b1ee) \- Ajout du jeton de description manquant pour la carte
 
-## v1.3.0
+## 1.3.0 (2023-06-26)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/127 - [82832a8](https://github.com/cds-snc/gcds-tokens/pull/127/commits/82832a87119f871687edd63f39ea16f8e34353cc) \- Nouveaux jetons pour le composant gcds-card
 - https://github.com/cds-snc/gcds-tokens/pull/127 - [26d1ee8](https://github.com/cds-snc/gcds-tokens/pull/127/commits/26d1ee89c6c0842e42fcdcf1b8b01eaffb406abe) \- Mise à jour du jeton de bordure de carte
 
-## v1.2.1
+## 1.2.1 (2023-06-22)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/128 - [3e72118](https://github.com/cds-snc/gcds-tokens/pull/128/commits/3e721187a5b1dda1637fe71443a5a0e82d901a0a) \- Ajout des jetons de composant manquants
 
-## v1.2.0
+## 1.2.0 (2023-06-21)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/126 - [a76688c](https://github.com/cds-snc/gcds-tokens/pull/126/commits/a76688c0ed9aa507f90a04268d7123d673e3fcbd) \- Fichiers base.json et base.js renommés à tokens.json et tokens.js pour améliorer la cohérence
 - https://github.com/cds-snc/gcds-tokens/pull/126 - [4f4ff47](https://github.com/cds-snc/gcds-tokens/pull/126/commits/4f4ff477ef4090fb694a740c534bc423dff1750f) \- Modification du chemin de jeton pour créer des fichiers de sortie pour chaque catégorie de jeton.
 
-## v1.1.3
+## 1.1.3 (2023-06-05)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/124 - [8c2aff2](https://github.com/cds-snc/gcds-tokens/pull/124/commits/8c2aff2c03db5d3f7aa08ae0271f71a3d7a8fc74) \- Suppression de la bordure active d’alerte et des jetons de bordure de pagination
 
-## v1.1.2
+## 1.1.2 (2023-05-31)
 
 ### Changement mineur
 
@@ -524,32 +524,32 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-tokens/pull/122 - [5098a50](https://github.com/cds-snc/gcds-tokens/pull/122/commits/5098a50df78c5a13e71e38cb9c33f39d852130eb) \- Validation que la signature du canada utilise du texte noir
 - https://github.com/cds-snc/gcds-tokens/pull/122 - [4d42cc5](https://github.com/cds-snc/gcds-tokens/pull/122/commits/4d42cc5a1d4b6f40f5ee258ed15edc41552295e6) \- Réorganisation des jetons de couleur bleue du clair au foncé
 
-## v1.1.1
+## 1.1.1 (2023-04-25)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/114 - [8fc59ab](https://github.com/cds-snc/gcds-tokens/pull/114/commits/8fc59ab3c488c4f912e5b7d93a8a4248f8e6fbf7) \- Ajout de nouveaux jetons de marge et de marge intérieure pour gcds-breadcrumbs
 
-## v1.1.0
+## 1.1.0 (2023-04-21)
 
 ### Changement mineur
 
 - https://github.com/cds-snc/gcds-tokens/pull/112 - [42956e2](https://github.com/cds-snc/gcds-tokens/pull/112/commits/42956e2e1475ab5257c14cb7583f36f3312a71ff) \- Ajout du composant résumé des erreurs
 - https://github.com/cds-snc/gcds-tokens/pull/112 - [0ac7a26](https://github.com/cds-snc/gcds-tokens/pull/112/commits/0ac7a26669217ed37d5fb48bafc30da4c2b5ad81) \- Ajout du jeton couleur de texte
 
-## v1.0.6
+## 1.0.6 (2023-04-21)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/113 - [a9b2712](https://github.com/cds-snc/gcds-tokens/pull/113/commits/a9b27127dc4cb47d51ed881d0dd2c6665b676802) \- Ajustement des jetons pour lang-toggle
 
-## v1.0.5
+## 1.0.5 (2023-03-30)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/111 - [bf64968](https://github.com/cds-snc/gcds-tokens/pull/111/commits/bf6496851ff3352e85663d58e69d81b711ac693b) \- Nouveaux jetons pour les composants chemin de navigation et détails
 
-## v1.0.4
+## 1.0.4 (2023-03-27)
 
 ### Correctif
 
@@ -557,13 +557,13 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-utility/pull/96 - [a733313](https://github.com/cds-snc/gcds-tokens/pull/96/commits/a733313f23590fa784bdeebf5e76771f221636fd) \- Mises à jour des couleurs de liens de pied de page
 - https://github.com/cds-snc/gcds-tokens/pull/106 - [6db5164](https://github.com/cds-snc/gcds-tokens/pull/106/commits/6db5164684226eac930e5d76633e07533a157aea) \- Ajout de jetons pour prendre en charge les boutons mobiles pleine largeur
 
-## v1.0.3
+## 1.0.3 (2023-03-09)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/93 - [ad9a291](https://github.com/cds-snc/gcds-tokens/pull/93/commits/ad9a2915571230b2a278a5f42400a77a33f7f1e6) \- Mise à jour de la couleur de sous-menu pour qu’elle soit plus claire
 
-## v1.0.2
+## 1.0.2 (2023-03-01)
 
 ### Correctif
 
@@ -571,14 +571,14 @@ Tout changement important à ce projet sera consigné dans le présent fichier.
 - https://github.com/cds-snc/gcds-tokens/pull/92 - [8806b49](https://github.com/cds-snc/gcds-tokens/pull/92/commits/8806b494d3933d9836a8bc86eb237caafe4fddcd) \- Ajouter une nouvelle couleur secondaire au texte
 - https://github.com/cds-snc/gcds-tokens/pull/92 - [99da08f](https://github.com/cds-snc/gcds-tokens/pull/92/commits/99da08f1619841e2f11c1bc2b995a4607809ea6d) \- Mise à jour de la couleur du texte désactivée pour un meilleur contraste des couleurs
 
-## v1.0.1
+## 1.0.1 (2023-02-22)
 
 ### Correctif
 
 - https://github.com/cds-snc/gcds-tokens/pull/90 - [48efe65](https://github.com/cds-snc/gcds-tokens/pull/90/commits/48efe65acbe3d4f6f72d246b14f9748ee2c3b09f) \- Mise à jour de conception aux composants bouton, étiquette, téléverseur de fichiers et pied de page
 - https://github.com/cds-snc/gcds-tokens/pull/90 - [7a9bc12](https://github.com/cds-snc/gcds-tokens/pull/90/commits/7a9bc126226c9653c1e20882ec1b5177fbd815b8) \- Ajout des jetons pour le texte des boutons uniquement
 
-## v1.0.0
+## 1.0.0 (2023-02-10)
 
 ### Nouvelles fonctionnalités
 


### PR DESCRIPTION
# Summary | Résumé

Noticed the changelog needed a bit of a cleanup. I added dates to all the releases we did before adding release-please and removed all the `chore` updates that made it into the changelog during the initial release-please setup.