### PR TITLE
fix: update radio check top to be correct value

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3707,7 +3707,7 @@
           "type": "spacing"
         },
         "top": {
-          "value": "0.1875rem",
+          "value": "0.9375rem",
           "type": "spacing"
         }
       },

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 15 Apr 2024 23:56:04 GMT
+ * Generated on Tue, 23 Apr 2024 18:49:21 GMT
  */
 
 :root {
@@ -694,7 +694,7 @@
   --gcds-radio-check-border-width: 0.3125rem;
   --gcds-radio-check-height-and-width: 1.125rem;
   --gcds-radio-check-left: 0.9375rem;
-  --gcds-radio-check-top: 0.1875rem;
+  --gcds-radio-check-top: 0.9375rem;
   --gcds-radio-danger-border: #d3080c;
   --gcds-radio-default-text: #333333;
   --gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 15 Apr 2024 23:56:04 GMT
+ * Generated on Tue, 23 Apr 2024 18:49:21 GMT
  */
 
 :root {
@@ -551,7 +551,7 @@
   --gcds-radio-check-border-width: 0.3125rem;
   --gcds-radio-check-height-and-width: 1.125rem;
   --gcds-radio-check-left: 0.9375rem;
-  --gcds-radio-check-top: 0.1875rem;
+  --gcds-radio-check-top: 0.9375rem;
   --gcds-radio-danger-border: #d3080c;
   --gcds-radio-default-text: #333333;
   --gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/css/components/radio.css
+++ b/build/web/css/components/radio.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 04 Apr 2024 18:09:58 GMT
+ * Generated on Tue, 23 Apr 2024 18:49:21 GMT
  */
 
 :root {
@@ -8,7 +8,7 @@
   --gcds-radio-check-border-width: 0.3125rem;
   --gcds-radio-check-height-and-width: 1.125rem;
   --gcds-radio-check-left: 0.9375rem;
-  --gcds-radio-check-top: 0.1875rem;
+  --gcds-radio-check-top: 0.9375rem;
   --gcds-radio-danger-border: #d3080c;
   --gcds-radio-default-text: #333333;
   --gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 15 Apr 2024 23:56:04 GMT
+ * Generated on Tue, 23 Apr 2024 18:49:21 GMT
  */
 
 :root {
@@ -694,7 +694,7 @@
   --gcds-radio-check-border-width: 0.3125rem;
   --gcds-radio-check-height-and-width: 1.125rem;
   --gcds-radio-check-left: 0.9375rem;
-  --gcds-radio-check-top: 0.1875rem;
+  --gcds-radio-check-top: 0.9375rem;
   --gcds-radio-danger-border: #d3080c;
   --gcds-radio-default-text: #333333;
   --gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 15 Apr 2024 23:56:04 GMT
+// Generated on Tue, 23 Apr 2024 18:49:21 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -692,7 +692,7 @@ $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
 $gcds-radio-check-height-and-width: 1.125rem;
 $gcds-radio-check-left: 0.9375rem;
-$gcds-radio-check-top: 0.1875rem;
+$gcds-radio-check-top: 0.9375rem;
 $gcds-radio-danger-border: #d3080c;
 $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 15 Apr 2024 23:56:04 GMT
+// Generated on Tue, 23 Apr 2024 18:49:20 GMT
 
 $gcds-link-focus-background: #0535d2;
 $gcds-link-focus-outline-width: 0.1875rem;
@@ -549,7 +549,7 @@ $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
 $gcds-radio-check-height-and-width: 1.125rem;
 $gcds-radio-check-left: 0.9375rem;
-$gcds-radio-check-top: 0.1875rem;
+$gcds-radio-check-top: 0.9375rem;
 $gcds-radio-danger-border: #d3080c;
 $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/scss/components/radio.scss
+++ b/build/web/scss/components/radio.scss
@@ -1,12 +1,12 @@
 
 // Do not edit directly
-// Generated on Thu, 04 Apr 2024 18:09:58 GMT
+// Generated on Tue, 23 Apr 2024 18:49:20 GMT
 
 $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
 $gcds-radio-check-height-and-width: 1.125rem;
 $gcds-radio-check-left: 0.9375rem;
-$gcds-radio-check-top: 0.1875rem;
+$gcds-radio-check-top: 0.9375rem;
 $gcds-radio-danger-border: #d3080c;
 $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 15 Apr 2024 23:56:03 GMT
+// Generated on Tue, 23 Apr 2024 18:49:20 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -692,7 +692,7 @@ $gcds-radio-border-radius: 100%;
 $gcds-radio-check-border-width: 0.3125rem;
 $gcds-radio-check-height-and-width: 1.125rem;
 $gcds-radio-check-left: 0.9375rem;
-$gcds-radio-check-top: 0.1875rem;
+$gcds-radio-check-top: 0.9375rem;
 $gcds-radio-danger-border: #d3080c;
 $gcds-radio-default-text: #333333;
 $gcds-radio-disabled-background: #d6d9dd;

--- a/tokens/components/radio/tokens.json
+++ b/tokens/components/radio/tokens.json
@@ -22,7 +22,7 @@
         "type": "spacing"
       },
       "top": {
-        "value": "{spacing.50.value}",
+        "value": "{spacing.250.value}",
         "type": "spacing"
       }
     },


### PR DESCRIPTION
# Summary | Résumé

Update `--gcds-radio-check-top` to `0.9375rem` to center the circle in a checked `gcds-radio-group`.

To test properly, use the [refactor/form-rewrite branch](https://github.com/cds-snc/gcds-components/tree/refactor/form-rewrite) on gcds-components.
