### PR TITLE
refactor: remove global black background token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -165,10 +165,6 @@
       }
     },
     "bg": {
-      "black": {
-        "value": "#000",
-        "type": "color"
-      },
       "dark": {
         "value": "#333333",
         "type": "color"

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -39,7 +39,6 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
-  --gcds-bg-black: #000000; /* Global bg color: black background */
   --gcds-bg-dark: #333333; /* Global bg color: dark background */
   --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
   --gcds-bg-primary: #26374a; /* Global bg color: primary background */

--- a/build/web/css/global.css
+++ b/build/web/css/global.css
@@ -14,7 +14,6 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
-  --gcds-bg-black: #000000; /* Global bg color: black background */
   --gcds-bg-dark: #333333; /* Global bg color: dark background */
   --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
   --gcds-bg-primary: #26374a; /* Global bg color: primary background */

--- a/build/web/css/global/color.css
+++ b/build/web/css/global/color.css
@@ -6,7 +6,6 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
-  --gcds-bg-black: #000000; /* Global bg color: black background */
   --gcds-bg-dark: #333333; /* Global bg color: dark background */
   --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
   --gcds-bg-primary: #26374a; /* Global bg color: primary background */

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -39,7 +39,6 @@
   --gcds-border-default: #7d828b; /* Global color: border default */
   --gcds-active-background: #000000; /* Global color: active background */
   --gcds-active-text: #ffffff; /* Global color: active text */
-  --gcds-bg-black: #000000; /* Global bg color: black background */
   --gcds-bg-dark: #333333; /* Global bg color: dark background */
   --gcds-bg-light: #f1f2f3; /* Global bg color: light background */
   --gcds-bg-primary: #26374a; /* Global bg color: primary background */

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -37,7 +37,6 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
-$gcds-bg-black: #000000; // Global bg color: black background
 $gcds-bg-dark: #333333; // Global bg color: dark background
 $gcds-bg-light: #f1f2f3; // Global bg color: light background
 $gcds-bg-primary: #26374a; // Global bg color: primary background

--- a/build/web/scss/global.scss
+++ b/build/web/scss/global.scss
@@ -12,7 +12,6 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
-$gcds-bg-black: #000000; // Global bg color: black background
 $gcds-bg-dark: #333333; // Global bg color: dark background
 $gcds-bg-light: #f1f2f3; // Global bg color: light background
 $gcds-bg-primary: #26374a; // Global bg color: primary background

--- a/build/web/scss/global/color.scss
+++ b/build/web/scss/global/color.scss
@@ -4,7 +4,6 @@
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
-$gcds-bg-black: #000000; // Global bg color: black background
 $gcds-bg-dark: #333333; // Global bg color: dark background
 $gcds-bg-light: #f1f2f3; // Global bg color: light background
 $gcds-bg-primary: #26374a; // Global bg color: primary background

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -37,7 +37,6 @@ $gcds-border-width-xl: 0.375rem; // Global border: width xl
 $gcds-border-default: #7d828b; // Global color: border default
 $gcds-active-background: #000000; // Global color: active background
 $gcds-active-text: #ffffff; // Global color: active text
-$gcds-bg-black: #000000; // Global bg color: black background
 $gcds-bg-dark: #333333; // Global bg color: dark background
 $gcds-bg-light: #f1f2f3; // Global bg color: light background
 $gcds-bg-primary: #26374a; // Global bg color: primary background

--- a/tokens/global/color/tokens.json
+++ b/tokens/global/color/tokens.json
@@ -12,11 +12,6 @@
     }
   },
   "bg": {
-    "black": {
-      "value": "{color.grayscale.1000.value}",
-      "type": "color",
-      "comment": "Global bg color: black background"
-    },
     "dark": {
       "value": "{color.grayscale.900.value}",
       "type": "color",


### PR DESCRIPTION
# Summary | Résumé

As discussed in the dev-design-sync channel, we are removing the global `bg-black` background token as it's currently unused and doesn't provide a clear purpose.