### PR TITLE
refactor: revert red error colour for error summary links

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1751,6 +1751,12 @@
           "type": "color"
         }
       },
+      "link": {
+        "color": {
+          "value": "#A62A1E",
+          "type": "color"
+        }
+      },
       "list": {
         "item": {
           "padding": {

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1745,12 +1745,6 @@
           "type": "borderWidth"
         }
       },
-      "focus": {
-        "color": {
-          "value": "#0535d2",
-          "type": "color"
-        }
-      },
       "link": {
         "color": {
           "value": "#A62A1E",

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 19:41:33 GMT
+ * Generated on Tue, 07 May 2024 16:51:19 GMT
  */
 
 :root {
@@ -338,6 +338,7 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
+  --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 07 May 2024 16:51:19 GMT
+ * Generated on Tue, 07 May 2024 16:59:56 GMT
  */
 
 :root {
@@ -337,7 +337,6 @@
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
-  --gcds-error-summary-focus-color: #0535d2;
   --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 19:41:33 GMT
+ * Generated on Tue, 07 May 2024 16:51:19 GMT
  */
 
 :root {
@@ -200,6 +200,7 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
+  --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 07 May 2024 16:51:19 GMT
+ * Generated on Tue, 07 May 2024 16:59:56 GMT
  */
 
 :root {
@@ -199,7 +199,6 @@
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
-  --gcds-error-summary-focus-color: #0535d2;
   --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/css/components/error-summary.css
+++ b/build/web/css/components/error-summary.css
@@ -1,12 +1,11 @@
 /**
  * Do not edit directly
- * Generated on Tue, 07 May 2024 16:51:19 GMT
+ * Generated on Tue, 07 May 2024 16:59:56 GMT
  */
 
 :root {
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
-  --gcds-error-summary-focus-color: #0535d2;
   --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/css/components/error-summary.css
+++ b/build/web/css/components/error-summary.css
@@ -1,12 +1,13 @@
 /**
  * Do not edit directly
- * Generated on Thu, 29 Feb 2024 19:14:54 GMT
+ * Generated on Tue, 07 May 2024 16:51:19 GMT
  */
 
 :root {
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
+  --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 Mar 2024 19:41:33 GMT
+ * Generated on Tue, 07 May 2024 16:51:19 GMT
  */
 
 :root {
@@ -338,6 +338,7 @@
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
   --gcds-error-summary-focus-color: #0535d2;
+  --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;
   --gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 07 May 2024 16:51:19 GMT
+ * Generated on Tue, 07 May 2024 16:59:56 GMT
  */
 
 :root {
@@ -337,7 +337,6 @@
   --gcds-error-message-padding: 0.75rem;
   --gcds-error-summary-border-color: #d3080c;
   --gcds-error-summary-border-width: 0.375rem;
-  --gcds-error-summary-focus-color: #0535d2;
   --gcds-error-summary-link-color: #a62a1e;
   --gcds-error-summary-list-item-padding: 0 0 0.75rem;
   --gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 05 Mar 2024 19:41:33 GMT
+// Generated on Tue, 07 May 2024 16:51:19 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -336,6 +336,7 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
+$gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 07 May 2024 16:51:19 GMT
+// Generated on Tue, 07 May 2024 16:59:56 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -335,7 +335,6 @@ $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
-$gcds-error-summary-focus-color: #0535d2;
 $gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 05 Mar 2024 19:41:32 GMT
+// Generated on Tue, 07 May 2024 16:51:19 GMT
 
 $gcds-link-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-link-font-regular: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -198,6 +198,7 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
+$gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 07 May 2024 16:51:19 GMT
+// Generated on Tue, 07 May 2024 16:59:56 GMT
 
 $gcds-link-font-small: 400 1.1111111111111112rem/135% "Noto Sans", sans-serif;
 $gcds-link-font-regular: 400 1.25rem/120% "Noto Sans", sans-serif;
@@ -197,7 +197,6 @@ $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
-$gcds-error-summary-focus-color: #0535d2;
 $gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/scss/components/error-summary.scss
+++ b/build/web/scss/components/error-summary.scss
@@ -1,10 +1,9 @@
 
 // Do not edit directly
-// Generated on Tue, 07 May 2024 16:51:19 GMT
+// Generated on Tue, 07 May 2024 16:59:56 GMT
 
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
-$gcds-error-summary-focus-color: #0535d2;
 $gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/build/web/scss/components/error-summary.scss
+++ b/build/web/scss/components/error-summary.scss
@@ -1,10 +1,11 @@
 
 // Do not edit directly
-// Generated on Thu, 29 Feb 2024 19:14:54 GMT
+// Generated on Tue, 07 May 2024 16:51:19 GMT
 
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
+$gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 05 Mar 2024 19:41:32 GMT
+// Generated on Tue, 07 May 2024 16:51:19 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -336,6 +336,7 @@ $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
 $gcds-error-summary-focus-color: #0535d2;
+$gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;
 $gcds-error-summary-margin: 0 0 2.25rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 07 May 2024 16:51:19 GMT
+// Generated on Tue, 07 May 2024 16:59:56 GMT
 
 $gcds-color-blue-100: #d7e5f5;
 $gcds-color-blue-500: #6584a6; // Must contrast 3:1 with white
@@ -335,7 +335,6 @@ $gcds-error-message-margin: 0 0 1.125rem;
 $gcds-error-message-padding: 0.75rem;
 $gcds-error-summary-border-color: #d3080c;
 $gcds-error-summary-border-width: 0.375rem;
-$gcds-error-summary-focus-color: #0535d2;
 $gcds-error-summary-link-color: #a62a1e;
 $gcds-error-summary-list-item-padding: 0 0 0.75rem;
 $gcds-error-summary-list-margin: 0 0 0 1.125rem;

--- a/tokens/components/error-summary/tokens.json
+++ b/tokens/components/error-summary/tokens.json
@@ -10,12 +10,6 @@
         "type": "borderWidth"
       }
     },
-    "focus": {
-      "color": {
-        "value": "{focus.textForm.value}",
-        "type": "color"
-      }
-    },
     "link": {
       "color": {
         "value": "{danger.text.value}",

--- a/tokens/components/error-summary/tokens.json
+++ b/tokens/components/error-summary/tokens.json
@@ -2,7 +2,7 @@
   "error-summary": {
     "border": {
       "color": {
-        "value": "{color.red.500.value}",
+        "value": "{danger.border.value}",
         "type": "color"
       },
       "width": {
@@ -13,6 +13,12 @@
     "focus": {
       "color": {
         "value": "{focus.textForm.value}",
+        "type": "color"
+      }
+    },
+    "link": {
+      "color": {
+        "value": "{danger.text.value}",
         "type": "color"
       }
     },


### PR DESCRIPTION
# Summary | Résumé

Keep red error colour for error summary links.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/899)