### PR TITLE
refactor: change monospace font to noto sans mono

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -682,7 +682,7 @@
         "type": "fontFamilies"
       },
       "monospace": {
-        "value": "\"Menlo\", sans-serif",
+        "value": "\"Noto Sans Mono\", monospace",
         "type": "fontFamilies"
       },
       "icons": {

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -146,7 +146,7 @@
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: "Lato", sans-serif;
   --gcds-font-families-body: "Noto Sans", sans-serif;
-  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-monospace: "Noto Sans Mono", monospace;
   --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/css/global.css
+++ b/build/web/css/global.css
@@ -61,7 +61,7 @@
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: "Lato", sans-serif;
   --gcds-font-families-body: "Noto Sans", sans-serif;
-  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-monospace: "Noto Sans Mono", monospace;
   --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/css/global/typography.css
+++ b/build/web/css/global/typography.css
@@ -9,7 +9,7 @@
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: "Lato", sans-serif;
   --gcds-font-families-body: "Noto Sans", sans-serif;
-  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-monospace: "Noto Sans Mono", monospace;
   --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -146,7 +146,7 @@
   --gcds-base-scale: 1.125;
   --gcds-font-families-heading: "Lato", sans-serif;
   --gcds-font-families-body: "Noto Sans", sans-serif;
-  --gcds-font-families-monospace: "Menlo", sans-serif;
+  --gcds-font-families-monospace: "Noto Sans Mono", monospace;
   --gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
   --gcds-font-sizes-caption: 1.1111111111111112rem;
   --gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -144,7 +144,7 @@ $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
 $gcds-font-families-heading: "Lato", sans-serif;
 $gcds-font-families-body: "Noto Sans", sans-serif;
-$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-monospace: "Noto Sans Mono", monospace;
 $gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/scss/global.scss
+++ b/build/web/scss/global.scss
@@ -59,7 +59,7 @@ $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
 $gcds-font-families-heading: "Lato", sans-serif;
 $gcds-font-families-body: "Noto Sans", sans-serif;
-$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-monospace: "Noto Sans Mono", monospace;
 $gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/scss/global/typography.scss
+++ b/build/web/scss/global/typography.scss
@@ -7,7 +7,7 @@ $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
 $gcds-font-families-heading: "Lato", sans-serif;
 $gcds-font-families-body: "Noto Sans", sans-serif;
-$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-monospace: "Noto Sans Mono", monospace;
 $gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -144,7 +144,7 @@ $gcds-base-line-height: 1.2; // Sets base line height to 24px
 $gcds-base-scale: 1.125;
 $gcds-font-families-heading: "Lato", sans-serif;
 $gcds-font-families-body: "Noto Sans", sans-serif;
-$gcds-font-families-monospace: "Menlo", sans-serif;
+$gcds-font-families-monospace: "Noto Sans Mono", monospace;
 $gcds-font-families-icons: "Font Awesome 6 Free", FontAwesome;
 $gcds-font-sizes-caption: 1.1111111111111112rem;
 $gcds-font-sizes-caption-mobile: 0.8888888888888888rem;

--- a/tokens/global/typography/tokens.js
+++ b/tokens/global/typography/tokens.js
@@ -26,7 +26,7 @@ const fontFamilies = {
     type: 'fontFamilies',
   },
   monospace: {
-    value: '"Menlo", sans-serif',
+    value: '"Noto Sans Mono", monospace',
     type: 'fontFamilies',
   },
   icons: {


### PR DESCRIPTION
# Summary | Résumé

Change monospace font from `Menlo` to `Noto Sans Mono` to have all fonts hosted in the same spot and update fallback to `monospace`.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/911)