### PR TITLE
fix: required label font weight

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2869,6 +2869,10 @@
         "type": "spacing"
       },
       "required": {
+        "fontWeight": {
+          "value": "400",
+          "type": "spacing"
+        },
         "margin": {
           "value": "0 0 0 0.375rem",
           "type": "spacing"

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -540,6 +540,7 @@
   --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
+  --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-padding: 0.5625rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -396,6 +396,7 @@
   --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
+  --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-padding: 0.5625rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;

--- a/build/web/css/components/label.css
+++ b/build/web/css/components/label.css
@@ -6,5 +6,6 @@
   --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
+  --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -540,6 +540,7 @@
   --gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
   --gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
   --gcds-label-margin: 0 0 0.375rem;
+  --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-lang-toggle-padding: 0.5625rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -538,6 +538,7 @@ $gcds-input-padding: 0.75rem;
 $gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
+$gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-padding: 0.5625rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -394,6 +394,7 @@ $gcds-input-padding: 0.75rem;
 $gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
+$gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-padding: 0.5625rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;

--- a/build/web/scss/components/label.scss
+++ b/build/web/scss/components/label.scss
@@ -4,4 +4,5 @@
 $gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
+$gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -538,6 +538,7 @@ $gcds-input-padding: 0.75rem;
 $gcds-label-font-desktop: 600 1.25rem/120% "Noto Sans", sans-serif;
 $gcds-label-font-mobile: 600 1rem/150% "Noto Sans", sans-serif;
 $gcds-label-margin: 0 0 0.375rem;
+$gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-lang-toggle-padding: 0.5625rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;

--- a/tokens/components/label/tokens.json
+++ b/tokens/components/label/tokens.json
@@ -25,6 +25,10 @@
       "type": "spacing"
     },
     "required": {
+      "fontWeight": {
+        "value": "{fontWeights.regular}",
+        "type": "spacing"
+      },
       "margin": {
         "value": "0 0 0 {spacing.100.value}",
         "type": "spacing"


### PR DESCRIPTION
# Summary | Résumé

Required form labels are currently using a bold font-weight when they should be using a regular font-weight. Adding a new font weight token for the required label.

[Zenhub ticket](https://app.zenhub.com/workspaces/design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1082)