### PR TITLE
fix: Update the red flag colour to be fip red

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -113,7 +113,7 @@
           "type": "color"
         },
         "flag": {
-          "value": "#FF0000",
+          "value": "#eb2d37",
           "type": "color"
         }
       },
@@ -3978,7 +3978,7 @@
     "signature": {
       "color": {
         "flag": {
-          "value": "#FF0000",
+          "value": "#eb2d37",
           "type": "color"
         },
         "text": {

--- a/build/web/css/.css
+++ b/build/web/css/.css
@@ -28,7 +28,7 @@
   --gcds-color-red-500: #d3080c; /* Must contrast 3:1 with white */
   --gcds-color-red-700: #a62a1e; /* Must contrast 7:1 with white */
   --gcds-color-red-900: #822117;
-  --gcds-color-red-flag: #ff0000; /* Signature flag colour */
+  --gcds-color-red-flag: #eb2d37; /* Signature flag colour - Fip red */
   --gcds-color-yellow-100: #faedd1;
   --gcds-color-yellow-500: #b3800f; /* Must contrast 3:1 with white */
   --gcds-border-radius-sm: 0.1875rem; /* Global border: radius sm */
@@ -724,7 +724,7 @@
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
-  --gcds-signature-color-flag: #ff0000;
+  --gcds-signature-color-flag: #eb2d37;
   --gcds-signature-color-text: #000000;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;

--- a/build/web/css/base.css
+++ b/build/web/css/base.css
@@ -28,7 +28,7 @@
   --gcds-color-red-500: #d3080c; /* Must contrast 3:1 with white */
   --gcds-color-red-700: #a62a1e; /* Must contrast 7:1 with white */
   --gcds-color-red-900: #822117;
-  --gcds-color-red-flag: #ff0000; /* Signature flag colour */
+  --gcds-color-red-flag: #eb2d37; /* Signature flag colour - Fip red */
   --gcds-color-yellow-100: #faedd1;
   --gcds-color-yellow-500: #b3800f; /* Must contrast 3:1 with white */
 }

--- a/build/web/css/base/color.css
+++ b/build/web/css/base/color.css
@@ -28,7 +28,7 @@
   --gcds-color-red-500: #d3080c; /* Must contrast 3:1 with white */
   --gcds-color-red-700: #a62a1e; /* Must contrast 7:1 with white */
   --gcds-color-red-900: #822117;
-  --gcds-color-red-flag: #ff0000; /* Signature flag colour */
+  --gcds-color-red-flag: #eb2d37; /* Signature flag colour - Fip red */
   --gcds-color-yellow-100: #faedd1;
   --gcds-color-yellow-500: #b3800f; /* Must contrast 3:1 with white */
 }

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -578,7 +578,7 @@
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
-  --gcds-signature-color-flag: #ff0000;
+  --gcds-signature-color-flag: #eb2d37;
   --gcds-signature-color-text: #000000;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;

--- a/build/web/css/components/signature.css
+++ b/build/web/css/components/signature.css
@@ -3,7 +3,7 @@
  */
 
 :root {
-  --gcds-signature-color-flag: #ff0000;
+  --gcds-signature-color-flag: #eb2d37;
   --gcds-signature-color-text: #000000;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -28,7 +28,7 @@
   --gcds-color-red-500: #d3080c; /* Must contrast 3:1 with white */
   --gcds-color-red-700: #a62a1e; /* Must contrast 7:1 with white */
   --gcds-color-red-900: #822117;
-  --gcds-color-red-flag: #ff0000; /* Signature flag colour */
+  --gcds-color-red-flag: #eb2d37; /* Signature flag colour - Fip red */
   --gcds-color-yellow-100: #faedd1;
   --gcds-color-yellow-500: #b3800f; /* Must contrast 3:1 with white */
   --gcds-border-radius-sm: 0.1875rem; /* Global border: radius sm */
@@ -724,7 +724,7 @@
   --gcds-side-nav-heading-margin: 0.5625rem;
   --gcds-side-nav-heading-padding: 0.9375rem;
   --gcds-side-nav-max-width: 20rem;
-  --gcds-signature-color-flag: #ff0000;
+  --gcds-signature-color-flag: #eb2d37;
   --gcds-signature-color-text: #000000;
   --gcds-signature-signature-height: 1.6875rem;
   --gcds-signature-white-default: #ffffff;

--- a/build/web/scss/.scss
+++ b/build/web/scss/.scss
@@ -26,7 +26,7 @@ $gcds-color-red-100: #fbddda;
 $gcds-color-red-500: #d3080c; // Must contrast 3:1 with white
 $gcds-color-red-700: #a62a1e; // Must contrast 7:1 with white
 $gcds-color-red-900: #822117;
-$gcds-color-red-flag: #ff0000; // Signature flag colour
+$gcds-color-red-flag: #eb2d37; // Signature flag colour - Fip red
 $gcds-color-yellow-100: #faedd1;
 $gcds-color-yellow-500: #b3800f; // Must contrast 3:1 with white
 $gcds-border-radius-sm: 0.1875rem; // Global border: radius sm
@@ -722,7 +722,7 @@ $gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
-$gcds-signature-color-flag: #ff0000;
+$gcds-signature-color-flag: #eb2d37;
 $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;

--- a/build/web/scss/base.scss
+++ b/build/web/scss/base.scss
@@ -26,6 +26,6 @@ $gcds-color-red-100: #fbddda;
 $gcds-color-red-500: #d3080c; // Must contrast 3:1 with white
 $gcds-color-red-700: #a62a1e; // Must contrast 7:1 with white
 $gcds-color-red-900: #822117;
-$gcds-color-red-flag: #ff0000; // Signature flag colour
+$gcds-color-red-flag: #eb2d37; // Signature flag colour - Fip red
 $gcds-color-yellow-100: #faedd1;
 $gcds-color-yellow-500: #b3800f; // Must contrast 3:1 with white

--- a/build/web/scss/base/color.scss
+++ b/build/web/scss/base/color.scss
@@ -26,6 +26,6 @@ $gcds-color-red-100: #fbddda;
 $gcds-color-red-500: #d3080c; // Must contrast 3:1 with white
 $gcds-color-red-700: #a62a1e; // Must contrast 7:1 with white
 $gcds-color-red-900: #822117;
-$gcds-color-red-flag: #ff0000; // Signature flag colour
+$gcds-color-red-flag: #eb2d37; // Signature flag colour - Fip red
 $gcds-color-yellow-100: #faedd1;
 $gcds-color-yellow-500: #b3800f; // Must contrast 3:1 with white

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -576,7 +576,7 @@ $gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
-$gcds-signature-color-flag: #ff0000;
+$gcds-signature-color-flag: #eb2d37;
 $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;

--- a/build/web/scss/components/signature.scss
+++ b/build/web/scss/components/signature.scss
@@ -1,7 +1,7 @@
 
 // Do not edit directly.
 
-$gcds-signature-color-flag: #ff0000;
+$gcds-signature-color-flag: #eb2d37;
 $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -26,7 +26,7 @@ $gcds-color-red-100: #fbddda;
 $gcds-color-red-500: #d3080c; // Must contrast 3:1 with white
 $gcds-color-red-700: #a62a1e; // Must contrast 7:1 with white
 $gcds-color-red-900: #822117;
-$gcds-color-red-flag: #ff0000; // Signature flag colour
+$gcds-color-red-flag: #eb2d37; // Signature flag colour - Fip red
 $gcds-color-yellow-100: #faedd1;
 $gcds-color-yellow-500: #b3800f; // Must contrast 3:1 with white
 $gcds-border-radius-sm: 0.1875rem; // Global border: radius sm
@@ -722,7 +722,7 @@ $gcds-side-nav-heading-font: 700 1.58203125rem/126.41975308641975% "Lato", sans-
 $gcds-side-nav-heading-margin: 0.5625rem;
 $gcds-side-nav-heading-padding: 0.9375rem;
 $gcds-side-nav-max-width: 20rem;
-$gcds-signature-color-flag: #ff0000;
+$gcds-signature-color-flag: #eb2d37;
 $gcds-signature-color-text: #000000;
 $gcds-signature-signature-height: 1.6875rem;
 $gcds-signature-white-default: #ffffff;

--- a/tokens/base/color/tokens.json
+++ b/tokens/base/color/tokens.json
@@ -105,9 +105,9 @@
     },
     "red": {
       "flag": {
-        "value": "#FF0000",
+        "value": "#eb2d37",
         "type": "color",
-        "comment": "Signature flag colour"
+        "comment": "Signature flag colour - Fip red"
       },
       "100": {
         "value": "#FBDDDA",


### PR DESCRIPTION
# Summary | Résumé

Update the `--gcds-color-red-flag` token to use FIP red to be compliant with [FIP policy](https://www.canada.ca/en/treasury-board-secretariat/services/government-communications/design-standard/colour-design-standard-fip.html).
