### PR TITLE
refactor: remove global font token for label

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -988,24 +988,6 @@
         },
         "type": "typography"
       },
-      "label": {
-        "value": {
-          "fontFamily": "'Noto Sans', sans-serif",
-          "fontWeight": "500",
-          "lineHeight": "160%",
-          "fontSize": "1.25rem"
-        },
-        "type": "typography"
-      },
-      "labelMobile": {
-        "value": {
-          "fontFamily": "'Noto Sans', sans-serif",
-          "fontWeight": "500",
-          "lineHeight": "155%",
-          "fontSize": "1.125rem"
-        },
-        "type": "typography"
-      },
       "text": {
         "value": {
           "fontFamily": "'Noto Sans', sans-serif",

--- a/build/web/css/global.css
+++ b/build/web/css/global.css
@@ -88,8 +88,6 @@
   --gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
   --gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
   --gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
   --gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/css/global/typography.css
+++ b/build/web/css/global/typography.css
@@ -20,8 +20,6 @@
   --gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
   --gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
   --gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
   --gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/css/global/typography/font.css
+++ b/build/web/css/global/typography/font.css
@@ -15,8 +15,6 @@
   --gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
   --gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
   --gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
   --gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -207,8 +207,6 @@
   --gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
   --gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
   --gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-  --gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
   --gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/scss/global.scss
+++ b/build/web/scss/global.scss
@@ -86,8 +86,6 @@ $gcds-font-h5: 700 1.5rem/133% 'Lato', sans-serif;
 $gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
 $gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
 $gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-$gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/scss/global/typography.scss
+++ b/build/web/scss/global/typography.scss
@@ -18,8 +18,6 @@ $gcds-font-h5: 700 1.5rem/133% 'Lato', sans-serif;
 $gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
 $gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
 $gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-$gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/scss/global/typography/font.scss
+++ b/build/web/scss/global/typography/font.scss
@@ -13,8 +13,6 @@ $gcds-font-h5: 700 1.5rem/133% 'Lato', sans-serif;
 $gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
 $gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
 $gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-$gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -205,8 +205,6 @@ $gcds-font-h5: 700 1.5rem/133% 'Lato', sans-serif;
 $gcds-font-h5-mobile: 700 1.375rem/127% 'Lato', sans-serif;
 $gcds-font-h6: 700 1.375rem/145% 'Lato', sans-serif;
 $gcds-font-h6-mobile: 700 1.25rem/140% 'Lato', sans-serif;
-$gcds-font-label: 500 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-font-label-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text: 400 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-font-text-mobile: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-font-text-mono: 400 1.25rem/160% 'Noto Sans Mono', monospace;

--- a/tokens/global/typography/font.json
+++ b/tokens/global/typography/font.json
@@ -108,24 +108,6 @@
       },
       "type": "typography"
     },
-    "label": {
-      "value": {
-        "fontFamily": "{fontFamilies.body}",
-        "fontWeight": "{fontWeights.medium}",
-        "lineHeight": "{lineHeights.text}",
-        "fontSize": "{fontSizes.text}"
-      },
-      "type": "typography"
-    },
-    "labelMobile": {
-      "value": {
-        "fontFamily": "{fontFamilies.body}",
-        "fontWeight": "{fontWeights.medium}",
-        "lineHeight": "{lineHeights.textMobile}",
-        "fontSize": "{fontSizes.textMobile}"
-      },
-      "type": "typography"
-    },
     "text": {
       "value": {
         "fontFamily": "{fontFamilies.body}",


### PR DESCRIPTION
# Summary | Résumé

As part of the rewrite, it became clear that we are currently not using the global font token for `label`. It isn't used in the code, or the design. We removed it to avoid confusion about which styles to use for non-heading text.