### PR TITLE
remove: remove old grid gap token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2654,9 +2654,6 @@
         "800": {
           "value": "4rem",
           "type": "spacing"
-        },
-        "_": {
-          "value": "3rem"
         }
       }
     },

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -344,7 +344,6 @@
   --gcds-grid-gap-700: 3.5rem;
   --gcds-grid-gap-750: 3.75rem;
   --gcds-grid-gap-800: 4rem;
-  --gcds-grid-gap: 3rem;
   --gcds-header-brand-border-color: #26374a;
   --gcds-header-brand-border-width: 0.1875rem;
   --gcds-header-brand-grid-gap: 0.75rem;

--- a/build/web/css/components/grid.css
+++ b/build/web/css/components/grid.css
@@ -22,5 +22,4 @@
   --gcds-grid-gap-700: 3.5rem;
   --gcds-grid-gap-750: 3.75rem;
   --gcds-grid-gap-800: 4rem;
-  --gcds-grid-gap: 3rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -504,7 +504,6 @@
   --gcds-grid-gap-700: 3.5rem;
   --gcds-grid-gap-750: 3.75rem;
   --gcds-grid-gap-800: 4rem;
-  --gcds-grid-gap: 3rem;
   --gcds-header-brand-border-color: #26374a;
   --gcds-header-brand-border-width: 0.1875rem;
   --gcds-header-brand-grid-gap: 0.75rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -342,7 +342,6 @@ $gcds-grid-gap-650: 3.25rem;
 $gcds-grid-gap-700: 3.5rem;
 $gcds-grid-gap-750: 3.75rem;
 $gcds-grid-gap-800: 4rem;
-$gcds-grid-gap: 3rem;
 $gcds-header-brand-border-color: #26374a;
 $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;

--- a/build/web/scss/components/grid.scss
+++ b/build/web/scss/components/grid.scss
@@ -20,4 +20,3 @@ $gcds-grid-gap-650: 3.25rem;
 $gcds-grid-gap-700: 3.5rem;
 $gcds-grid-gap-750: 3.75rem;
 $gcds-grid-gap-800: 4rem;
-$gcds-grid-gap: 3rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -502,7 +502,6 @@ $gcds-grid-gap-650: 3.25rem;
 $gcds-grid-gap-700: 3.5rem;
 $gcds-grid-gap-750: 3.75rem;
 $gcds-grid-gap-800: 4rem;
-$gcds-grid-gap: 3rem;
 $gcds-header-brand-border-color: #26374a;
 $gcds-header-brand-border-width: 0.1875rem;
 $gcds-header-brand-grid-gap: 0.75rem;

--- a/tokens/components/grid/tokens.json
+++ b/tokens/components/grid/tokens.json
@@ -17,7 +17,6 @@
       }
     },
     "gap": {
-      "_": { "value": "3rem"},
       "150": {
         "value": "{spacing.150.value}",
         "type": "spacing"


### PR DESCRIPTION
# Summary | Résumé

Removing the old grid gap token as it's been replaced with the more flexible options added in [this PR](https://github.com/cds-snc/gcds-tokens/pull/375).