### PR TITLE
feat: Update language toggle tokens for mandatory elements alignment

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3373,6 +3373,26 @@
       }
     },
     "lang-toggle": {
+      "font": {
+        "desktop": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "400",
+            "lineHeight": "150%",
+            "fontSize": "1rem"
+          },
+          "type": "typography"
+        },
+        "mobile": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "700",
+            "lineHeight": "150%",
+            "fontSize": "1.125rem"
+          },
+          "type": "typography"
+        }
+      },
       "padding": {
         "value": "0.5rem 0.75rem",
         "type": "spacing"

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3387,14 +3387,14 @@
           "value": {
             "fontFamily": "'Noto Sans', sans-serif",
             "fontWeight": "700",
-            "lineHeight": "150%",
+            "lineHeight": "155%",
             "fontSize": "1.125rem"
           },
           "type": "typography"
         }
       },
       "padding": {
-        "value": "0.5rem 0.75rem",
+        "value": "0.625rem 0.75rem",
         "type": "spacing"
       }
     },

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -486,6 +486,8 @@
   --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-label-text: #333333;
+  --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
   --gcds-lang-toggle-padding: 0.5rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -487,8 +487,8 @@
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-label-text: #333333;
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.5rem 0.75rem;
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
+  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
   --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/css/components/lang-toggle.css
+++ b/build/web/css/components/lang-toggle.css
@@ -3,5 +3,7 @@
  */
 
 :root {
+  --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
   --gcds-lang-toggle-padding: 0.5rem 0.75rem;
 }

--- a/build/web/css/components/lang-toggle.css
+++ b/build/web/css/components/lang-toggle.css
@@ -4,6 +4,6 @@
 
 :root {
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.5rem 0.75rem;
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
+  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -647,8 +647,8 @@
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-label-text: #333333;
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.5rem 0.75rem;
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
+  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
   --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -646,6 +646,8 @@
   --gcds-label-required-font-weight: 400;
   --gcds-label-required-margin: 0 0 0 0.375rem;
   --gcds-label-text: #333333;
+  --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
   --gcds-lang-toggle-padding: 0.5rem 0.75rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -484,6 +484,8 @@ $gcds-label-margin: 0 0 0.5rem;
 $gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
+$gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
 $gcds-lang-toggle-padding: 0.5rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -485,8 +485,8 @@ $gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.5rem 0.75rem;
+$gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
+$gcds-lang-toggle-padding: 0.625rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
 $gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/scss/components/lang-toggle.scss
+++ b/build/web/scss/components/lang-toggle.scss
@@ -2,5 +2,5 @@
 // Do not edit directly, this file was auto-generated.
 
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.5rem 0.75rem;
+$gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
+$gcds-lang-toggle-padding: 0.625rem 0.75rem;

--- a/build/web/scss/components/lang-toggle.scss
+++ b/build/web/scss/components/lang-toggle.scss
@@ -1,4 +1,6 @@
 
 // Do not edit directly, this file was auto-generated.
 
+$gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
 $gcds-lang-toggle-padding: 0.5rem 0.75rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -645,8 +645,8 @@ $gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.5rem 0.75rem;
+$gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
+$gcds-lang-toggle-padding: 0.625rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
 $gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -644,6 +644,8 @@ $gcds-label-margin: 0 0 0.5rem;
 $gcds-label-required-font-weight: 400;
 $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
+$gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-lang-toggle-font-mobile: 700 1.125rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
 $gcds-lang-toggle-padding: 0.5rem 0.75rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;

--- a/tokens/components/lang-toggle/tokens.json
+++ b/tokens/components/lang-toggle/tokens.json
@@ -23,7 +23,7 @@
       }
     },
     "padding": {
-      "value": "{spacing.100.value} {spacing.150.value}",
+      "value": "{spacing.125.value} {spacing.150.value}",
       "type": "spacing"
     }
   }

--- a/tokens/components/lang-toggle/tokens.json
+++ b/tokens/components/lang-toggle/tokens.json
@@ -1,5 +1,27 @@
 {
   "lang-toggle": {
+    "font": {
+      "desktop": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "{lineHeights.textSmallMobile}",
+          "fontSize": "{fontSizes.textSmallMobile}"
+        },
+        "type": "typography",
+        "comment": "Mandatory elements alignment: sub-components of header use 16px font"
+      },
+      "mobile": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.textMobile}",
+          "fontSize": "{fontSizes.textMobile}"
+        },
+        "type": "typography",
+        "comment": "Mandatory elements alignment: size 18px "
+      }
+    },
     "padding": {
       "value": "{spacing.100.value} {spacing.150.value}",
       "type": "spacing"


### PR DESCRIPTION
# Summary | Résumé

To match requirements for mandatory elements alignment, add font tokens to language toggle component tokens.

## Requirements

- Language toggle uses `16px` font for desktop as is required for elements in the header.
- Language toggle uses `18px` font with a font weight of `700`/`bold` on mobile.

## Extras

- Bumped vertical padding from `spacing-100` to `spacing-125` to allow mobile link to be compliant with AAA standards

https://github.com/cds-snc/design-gc-conception/issues/1333

To be tested with https://github.com/cds-snc/gcds-components/pull/741
