### PR TITLE
feat: Add breadcrumb item font token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1411,6 +1411,15 @@
             "type": "spacing"
           }
         },
+        "font": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "400",
+            "lineHeight": "150%",
+            "fontSize": "1rem"
+          },
+          "type": "typography"
+        },
         "margin": {
           "value": "0.5rem 0.25rem",
           "type": "spacing"

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -129,6 +129,7 @@
   --gcds-alert-warning-icon: #b3800f;
   --gcds-alert-warning-text: #333333;
   --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/css/components/breadcrumbs.css
+++ b/build/web/css/components/breadcrumbs.css
@@ -4,6 +4,7 @@
 
 :root {
   --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -289,6 +289,7 @@
   --gcds-alert-warning-icon: #b3800f;
   --gcds-alert-warning-text: #333333;
   --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -127,6 +127,7 @@ $gcds-alert-warning-background: #faedd1;
 $gcds-alert-warning-icon: #b3800f;
 $gcds-alert-warning-text: #333333;
 $gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/scss/components/breadcrumbs.scss
+++ b/build/web/scss/components/breadcrumbs.scss
@@ -2,6 +2,7 @@
 // Do not edit directly, this file was auto-generated.
 
 $gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -287,6 +287,7 @@ $gcds-alert-warning-background: #faedd1;
 $gcds-alert-warning-icon: #b3800f;
 $gcds-alert-warning-text: #333333;
 $gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/tokens/components/breadcrumbs/tokens.json
+++ b/tokens/components/breadcrumbs/tokens.json
@@ -7,6 +7,16 @@
           "type": "spacing"
         }
       },
+      "font": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "{lineHeights.textSmallMobile}",
+          "fontSize": "{fontSizes.textSmallMobile}"
+        },
+        "type": "typography",
+        "comment": "Mandatory elements alignment: sub-components of header use 16px font"
+      },
       "margin": {
         "value": "{spacing.100.value} {spacing.50.value}",
         "type": "spacing"


### PR DESCRIPTION
# Summary | Résumé

To match requirements for mandatory elements alignment, add font token to breadcrumb item component tokens.

## Requirements

- Breadcrumbs uses size `16px` font since it is a sub-component of the header.

https://github.com/cds-snc/design-gc-conception/issues/1354

To be used with https://github.com/cds-snc/gcds-components/pull/742