### PR TITLE
feat: Update search component tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -4188,7 +4188,7 @@
       },
       "button": {
         "padding": {
-          "value": "0.125rem 0.25rem",
+          "value": "0.125rem",
           "type": "spacing"
         }
       },

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -4173,18 +4173,22 @@
     },
     "search": {
       "border": {
+        "color": {
+          "value": "#D6D9DD",
+          "type": "color"
+        },
         "radius": {
           "value": "0.375rem 0 0 0.375rem",
           "type": "borderRadius"
         },
         "width": {
-          "value": "0.125rem",
+          "value": "0.0625rem",
           "type": "borderWidth"
         }
       },
       "button": {
         "padding": {
-          "value": "0.5rem",
+          "value": "0.125rem 0.25rem",
           "type": "spacing"
         }
       },
@@ -4215,28 +4219,39 @@
         }
       },
       "font": {
-        "desktop": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "400",
-            "lineHeight": "160%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
+        "value": {
+          "fontFamily": "'Noto Sans', sans-serif",
+          "fontWeight": "400",
+          "lineHeight": "150%",
+          "fontSize": "1rem"
         },
-        "mobile": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "400",
-            "lineHeight": "160%",
-            "fontSize": "1.125rem"
-          },
-          "type": "typography"
-        }
+        "type": "typography"
+      },
+      "fontDesktop": {
+        "value": {
+          "fontFamily": "'Noto Sans', sans-serif",
+          "fontWeight": "400",
+          "lineHeight": "160%",
+          "fontSize": "1.25rem"
+        },
+        "type": "typography"
+      },
+      "fontMobile": {
+        "value": {
+          "fontFamily": "'Noto Sans', sans-serif",
+          "fontWeight": "400",
+          "lineHeight": "160%",
+          "fontSize": "1.125rem"
+        },
+        "type": "typography"
       },
       "margin": {
         "value": "0 0 0.125rem",
         "type": "spacing"
+      },
+      "maxHeight": {
+        "value": "2.75rem",
+        "type": "sizing"
       },
       "minWidthAndHeight": {
         "value": "3rem",
@@ -4249,7 +4264,7 @@
         }
       },
       "padding": {
-        "value": "0.5rem 0.75rem",
+        "value": "0.375rem 0 0.375rem 0.75rem",
         "type": "spacing"
       }
     },

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -625,20 +625,23 @@
   --gcds-radio-margin: 0 0 1.125rem;
   --gcds-radio-max-width: 46.5rem;
   --gcds-radio-padding: 0.5rem;
-  --gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-  --gcds-search-border-width: 0.125rem;
-  --gcds-search-button-padding: 0.5rem;
+  --gcds-search-border-color: #d6d9dd;
+  --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
+  --gcds-search-border-width: 0.0625rem;
+  --gcds-search-button-padding: 0.125rem 0.25rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
-  --gcds-search-focus-border-radius: 0.125rem;
+  --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
+  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-min-width-and-height: 3rem;
+  --gcds-search-max-height: 2.75rem;
+  --gcds-search-min-width-and-height: 3rem; /* Will be removed in separate pull request */
   --gcds-search-outline-width: 0.25rem;
-  --gcds-search-padding: 0.5rem 0.75rem;
+  --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
   --gcds-select-arrow-position-x: calc(100% - 0.75rem);
   --gcds-select-border-radius: 0.125rem;
   --gcds-select-border-width: 0.125rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -628,7 +628,7 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
   --gcds-search-border-width: 0.0625rem;
-  --gcds-search-button-padding: 0.125rem 0.25rem;
+  --gcds-search-button-padding: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */

--- a/build/web/css/components/search.css
+++ b/build/web/css/components/search.css
@@ -6,7 +6,7 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
   --gcds-search-border-width: 0.0625rem;
-  --gcds-search-button-padding: 0.125rem 0.25rem;
+  --gcds-search-button-padding: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */

--- a/build/web/css/components/search.css
+++ b/build/web/css/components/search.css
@@ -3,18 +3,21 @@
  */
 
 :root {
-  --gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-  --gcds-search-border-width: 0.125rem;
-  --gcds-search-button-padding: 0.5rem;
+  --gcds-search-border-color: #d6d9dd;
+  --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
+  --gcds-search-border-width: 0.0625rem;
+  --gcds-search-button-padding: 0.125rem 0.25rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
-  --gcds-search-focus-border-radius: 0.125rem;
+  --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
+  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-min-width-and-height: 3rem;
+  --gcds-search-max-height: 2.75rem;
+  --gcds-search-min-width-and-height: 3rem; /* Will be removed in separate pull request */
   --gcds-search-outline-width: 0.25rem;
-  --gcds-search-padding: 0.5rem 0.75rem;
+  --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -785,20 +785,23 @@
   --gcds-radio-margin: 0 0 1.125rem;
   --gcds-radio-max-width: 46.5rem;
   --gcds-radio-padding: 0.5rem;
-  --gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-  --gcds-search-border-width: 0.125rem;
-  --gcds-search-button-padding: 0.5rem;
+  --gcds-search-border-color: #d6d9dd;
+  --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
+  --gcds-search-border-width: 0.0625rem;
+  --gcds-search-button-padding: 0.125rem 0.25rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
-  --gcds-search-focus-border-radius: 0.125rem;
+  --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+  --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
+  --gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
+  --gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; /* Will be removed in separate pull request */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-min-width-and-height: 3rem;
+  --gcds-search-max-height: 2.75rem;
+  --gcds-search-min-width-and-height: 3rem; /* Will be removed in separate pull request */
   --gcds-search-outline-width: 0.25rem;
-  --gcds-search-padding: 0.5rem 0.75rem;
+  --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
   --gcds-select-arrow-position-x: calc(100% - 0.75rem);
   --gcds-select-border-radius: 0.125rem;
   --gcds-select-border-width: 0.125rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -788,7 +788,7 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-radius: 0.375rem 0 0 0.375rem; /* Will be removed in separate pull request */
   --gcds-search-border-width: 0.0625rem;
-  --gcds-search-button-padding: 0.125rem 0.25rem;
+  --gcds-search-button-padding: 0.125rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-radius: 0.125rem; /* Will be removed in separate pull request */

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -623,20 +623,23 @@ $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 0 0 1.125rem;
 $gcds-radio-max-width: 46.5rem;
 $gcds-radio-padding: 0.5rem;
-$gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-$gcds-search-border-width: 0.125rem;
-$gcds-search-button-padding: 0.5rem;
+$gcds-search-border-color: #d6d9dd;
+$gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
+$gcds-search-border-width: 0.0625rem;
+$gcds-search-button-padding: 0.125rem 0.25rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
-$gcds-search-focus-border-radius: 0.125rem;
+$gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+$gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
+$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-min-width-and-height: 3rem;
+$gcds-search-max-height: 2.75rem;
+$gcds-search-min-width-and-height: 3rem; // Will be removed in separate pull request
 $gcds-search-outline-width: 0.25rem;
-$gcds-search-padding: 0.5rem 0.75rem;
+$gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
 $gcds-select-arrow-position-x: calc(100% - 0.75rem);
 $gcds-select-border-radius: 0.125rem;
 $gcds-select-border-width: 0.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -626,7 +626,7 @@ $gcds-radio-padding: 0.5rem;
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
 $gcds-search-border-width: 0.0625rem;
-$gcds-search-button-padding: 0.125rem 0.25rem;
+$gcds-search-button-padding: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request

--- a/build/web/scss/components/search.scss
+++ b/build/web/scss/components/search.scss
@@ -1,17 +1,20 @@
 
 // Do not edit directly, this file was auto-generated.
 
-$gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-$gcds-search-border-width: 0.125rem;
-$gcds-search-button-padding: 0.5rem;
+$gcds-search-border-color: #d6d9dd;
+$gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
+$gcds-search-border-width: 0.0625rem;
+$gcds-search-button-padding: 0.125rem 0.25rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
-$gcds-search-focus-border-radius: 0.125rem;
+$gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+$gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
+$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-min-width-and-height: 3rem;
+$gcds-search-max-height: 2.75rem;
+$gcds-search-min-width-and-height: 3rem; // Will be removed in separate pull request
 $gcds-search-outline-width: 0.25rem;
-$gcds-search-padding: 0.5rem 0.75rem;
+$gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;

--- a/build/web/scss/components/search.scss
+++ b/build/web/scss/components/search.scss
@@ -4,7 +4,7 @@
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
 $gcds-search-border-width: 0.0625rem;
-$gcds-search-button-padding: 0.125rem 0.25rem;
+$gcds-search-button-padding: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -786,7 +786,7 @@ $gcds-radio-padding: 0.5rem;
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
 $gcds-search-border-width: 0.0625rem;
-$gcds-search-button-padding: 0.125rem 0.25rem;
+$gcds-search-button-padding: 0.125rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -783,20 +783,23 @@ $gcds-radio-label-padding: 0 0 0 3.75rem;
 $gcds-radio-margin: 0 0 1.125rem;
 $gcds-radio-max-width: 46.5rem;
 $gcds-radio-padding: 0.5rem;
-$gcds-search-border-radius: 0.375rem 0 0 0.375rem;
-$gcds-search-border-width: 0.125rem;
-$gcds-search-button-padding: 0.5rem;
+$gcds-search-border-color: #d6d9dd;
+$gcds-search-border-radius: 0.375rem 0 0 0.375rem; // Will be removed in separate pull request
+$gcds-search-border-width: 0.0625rem;
+$gcds-search-button-padding: 0.125rem 0.25rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
-$gcds-search-focus-border-radius: 0.125rem;
+$gcds-search-focus-border-radius: 0.125rem; // Will be removed in separate pull request
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
-$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif;
-$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif;
+$gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
+$gcds-search-font-desktop: 400 1.25rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
+$gcds-search-font-mobile: 400 1.125rem/160% 'Noto Sans', sans-serif; // Will be removed in separate pull request
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-min-width-and-height: 3rem;
+$gcds-search-max-height: 2.75rem;
+$gcds-search-min-width-and-height: 3rem; // Will be removed in separate pull request
 $gcds-search-outline-width: 0.25rem;
-$gcds-search-padding: 0.5rem 0.75rem;
+$gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
 $gcds-select-arrow-position-x: calc(100% - 0.75rem);
 $gcds-select-border-radius: 0.125rem;
 $gcds-select-border-width: 0.125rem;

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -17,7 +17,7 @@
     },
     "button": {
       "padding": {
-        "value": "{spacing.25.value} {spacing.50.value}",
+        "value": "{spacing.25.value}",
         "type": "spacing"
       }
     },

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -1,18 +1,23 @@
 {
   "search": {
     "border": {
+      "color": {
+        "value": "{color.grayscale.100.value}",
+        "type": "color"
+      },
       "radius": {
         "value": "{border.radius.md.value} 0 0 {border.radius.md.value}",
-        "type": "borderRadius"
+        "type": "borderRadius",
+        "comment": "Will be removed in separate pull request"
       },
       "width": {
-        "value": "{border.width.md.value}",
+        "value": "{border.width.sm.value}",
         "type": "borderWidth"
       }
     },
     "button": {
       "padding": {
-        "value": "{spacing.100.value}",
+        "value": "{spacing.25.value} {spacing.50.value}",
         "type": "spacing"
       }
     },
@@ -30,7 +35,8 @@
       "border": {
         "radius": {
           "value": "{border.radius.sm.value}",
-          "type": "borderRadius"
+          "type": "borderRadius",
+          "comment": "Will be removed in separate pull request"
         },
         "color": {
           "value": "{focus.border.value}",
@@ -43,32 +49,47 @@
       }
     },
     "font": {
-      "desktop": {
-        "value": {
-          "fontFamily": "{fontFamilies.body}",
-          "fontWeight": "{fontWeights.regular}",
-          "lineHeight": "{lineHeights.text}",
-          "fontSize": "{fontSizes.text}"
-        },
-        "type": "typography"
+      "value": {
+        "fontFamily": "{fontFamilies.body}",
+        "fontWeight": "{fontWeights.regular}",
+        "lineHeight": "{lineHeights.textSmallMobile}",
+        "fontSize": "{fontSizes.textSmallMobile}"
       },
-      "mobile": {
-        "value": {
-          "fontFamily": "{fontFamilies.body}",
-          "fontWeight": "{fontWeights.regular}",
-          "lineHeight": "{lineHeights.text}",
-          "fontSize": "{fontSizes.textMobile}"
-        },
-        "type": "typography"
-      }
+      "type": "typography",
+      "comment": "Mandatory elements alignment: sub-components of header use 16px font"
+    },
+    "fontDesktop": {
+      "value": {
+        "fontFamily": "{fontFamilies.body}",
+        "fontWeight": "{fontWeights.regular}",
+        "lineHeight": "{lineHeights.text}",
+        "fontSize": "{fontSizes.text}"
+      },
+      "type": "typography",
+      "comment": "Will be removed in separate pull request"
+    },
+    "fontMobile": {
+      "value": {
+        "fontFamily": "{fontFamilies.body}",
+        "fontWeight": "{fontWeights.regular}",
+        "lineHeight": "{lineHeights.text}",
+        "fontSize": "{fontSizes.textMobile}"
+      },
+      "type": "typography",
+      "comment": "Will be removed in separate pull request"
     },
     "margin": {
       "value": "0 0 {spacing.25.value}",
       "type": "spacing"
     },
+    "maxHeight": {
+      "value": "{spacing.550.value}",
+      "type": "sizing"
+    },
     "minWidthAndHeight": {
       "value": "{spacing.600.value}",
-      "type": "sizing"
+      "type": "sizing",
+      "comment": "Will be removed in separate pull request"
     },
     "outline": {
       "width": {
@@ -77,7 +98,7 @@
       }
     },
     "padding": {
-      "value": "{spacing.100.value} {spacing.150.value}",
+      "value": "{spacing.75.value} 0 {spacing.75.value} {spacing.150.value}",
       "type": "spacing"
     }
   }


### PR DESCRIPTION
# Summary | Résumé

To match requirements for mandatory elements alignment, update search component tokens.

Search component tokens that are no longer in use will be removed in a separate pull request tagged `remove:` once this pull request has been merged.

https://github.com/cds-snc/design-gc-conception/issues/1335

## Changes

- Set search to only use `16px` font as it is a sub-component of the header
- Change the border colour to `grayscale-100`
- Remove border radius
- Adjust padding to match font updates
- Reduce border width to `1px`

To be used in https://github.com/cds-snc/gcds-components/pull/743

