### PR TITLE
fix: adjust language-toggle padding to match design

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3403,7 +3403,7 @@
         }
       },
       "padding": {
-        "value": "0.625rem 0.75rem",
+        "value": "0.5rem 0.625rem",
         "type": "spacing"
       }
     },

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -489,7 +489,7 @@
   --gcds-label-text: #333333;
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
+  --gcds-lang-toggle-padding: 0.5rem 0.625rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
   --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/css/components/lang-toggle.css
+++ b/build/web/css/components/lang-toggle.css
@@ -5,5 +5,5 @@
 :root {
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
+  --gcds-lang-toggle-padding: 0.5rem 0.625rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -649,7 +649,7 @@
   --gcds-label-text: #333333;
   --gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; /* Mandatory elements alignment: size 18px  */
-  --gcds-lang-toggle-padding: 0.625rem 0.75rem;
+  --gcds-lang-toggle-padding: 0.5rem 0.625rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
   --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -487,7 +487,7 @@ $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.625rem 0.75rem;
+$gcds-lang-toggle-padding: 0.5rem 0.625rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
 $gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/build/web/scss/components/lang-toggle.scss
+++ b/build/web/scss/components/lang-toggle.scss
@@ -3,4 +3,4 @@
 
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.625rem 0.75rem;
+$gcds-lang-toggle-padding: 0.5rem 0.625rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -647,7 +647,7 @@ $gcds-label-required-margin: 0 0 0 0.375rem;
 $gcds-label-text: #333333;
 $gcds-lang-toggle-font-desktop: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Mandatory elements alignment: size 18px 
-$gcds-lang-toggle-padding: 0.625rem 0.75rem;
+$gcds-lang-toggle-padding: 0.5rem 0.625rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
 $gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;

--- a/tokens/components/lang-toggle/tokens.json
+++ b/tokens/components/lang-toggle/tokens.json
@@ -23,7 +23,7 @@
       }
     },
     "padding": {
-      "value": "{spacing.125.value} {spacing.150.value}",
+      "value": "{spacing.100.value} {spacing.125.value}",
       "type": "spacing"
     }
   }


### PR DESCRIPTION
# Summary | Résumé

Adjust language toggle padding from `{spacing.125.value} {spacing.150.value}` to `{spacing.100.value} {spacing.125.value}` to match design in figma.
