### PR TITLE
feat: Add search tokens for width, height and placeholder colour

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -4186,6 +4186,10 @@
         "padding": {
           "value": "0.125rem",
           "type": "spacing"
+        },
+        "widthHeight": {
+          "value": "2.5rem",
+          "type": "sizing"
         }
       },
       "default": {
@@ -4224,7 +4228,7 @@
         "type": "spacing"
       },
       "maxHeight": {
-        "value": "2.75rem",
+        "value": "2.5rem",
         "type": "sizing"
       },
       "outline": {
@@ -4236,6 +4240,10 @@
       "padding": {
         "value": "0.375rem 0 0.375rem 0.75rem",
         "type": "spacing"
+      },
+      "placeholder": {
+        "value": "#545961",
+        "type": "color"
       }
     },
     "select": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -628,15 +628,17 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-width: 0.0625rem;
   --gcds-search-button-padding: 0.125rem;
+  --gcds-search-button-width-height: 2.5rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-max-height: 2.75rem;
+  --gcds-search-max-height: 2.5rem;
   --gcds-search-outline-width: 0.25rem;
   --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+  --gcds-search-placeholder: #545961;
   --gcds-select-arrow-position-x: calc(100% - 0.75rem);
   --gcds-select-border-radius: 0.125rem;
   --gcds-select-border-width: 0.125rem;

--- a/build/web/css/components/search.css
+++ b/build/web/css/components/search.css
@@ -6,13 +6,15 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-width: 0.0625rem;
   --gcds-search-button-padding: 0.125rem;
+  --gcds-search-button-width-height: 2.5rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-max-height: 2.75rem;
+  --gcds-search-max-height: 2.5rem;
   --gcds-search-outline-width: 0.25rem;
   --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+  --gcds-search-placeholder: #545961;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -788,15 +788,17 @@
   --gcds-search-border-color: #d6d9dd;
   --gcds-search-border-width: 0.0625rem;
   --gcds-search-button-padding: 0.125rem;
+  --gcds-search-button-width-height: 2.5rem;
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
-  --gcds-search-max-height: 2.75rem;
+  --gcds-search-max-height: 2.5rem;
   --gcds-search-outline-width: 0.25rem;
   --gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+  --gcds-search-placeholder: #545961;
   --gcds-select-arrow-position-x: calc(100% - 0.75rem);
   --gcds-select-border-radius: 0.125rem;
   --gcds-select-border-width: 0.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -626,15 +626,17 @@ $gcds-radio-padding: 0.5rem;
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-width: 0.0625rem;
 $gcds-search-button-padding: 0.125rem;
+$gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-max-height: 2.75rem;
+$gcds-search-max-height: 2.5rem;
 $gcds-search-outline-width: 0.25rem;
 $gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+$gcds-search-placeholder: #545961;
 $gcds-select-arrow-position-x: calc(100% - 0.75rem);
 $gcds-select-border-radius: 0.125rem;
 $gcds-select-border-width: 0.125rem;

--- a/build/web/scss/components/search.scss
+++ b/build/web/scss/components/search.scss
@@ -4,12 +4,14 @@
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-width: 0.0625rem;
 $gcds-search-button-padding: 0.125rem;
+$gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-max-height: 2.75rem;
+$gcds-search-max-height: 2.5rem;
 $gcds-search-outline-width: 0.25rem;
 $gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+$gcds-search-placeholder: #545961;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -786,15 +786,17 @@ $gcds-radio-padding: 0.5rem;
 $gcds-search-border-color: #d6d9dd;
 $gcds-search-border-width: 0.0625rem;
 $gcds-search-button-padding: 0.125rem;
+$gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
-$gcds-search-max-height: 2.75rem;
+$gcds-search-max-height: 2.5rem;
 $gcds-search-outline-width: 0.25rem;
 $gcds-search-padding: 0.375rem 0 0.375rem 0.75rem;
+$gcds-search-placeholder: #545961;
 $gcds-select-arrow-position-x: calc(100% - 0.75rem);
 $gcds-select-border-radius: 0.125rem;
 $gcds-select-border-width: 0.125rem;

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -14,6 +14,10 @@
       "padding": {
         "value": "{spacing.25.value}",
         "type": "spacing"
+      },
+      "widthHeight": {
+        "value": "{spacing.500.value}",
+        "type": "sizing"
       }
     },
     "default": {
@@ -53,7 +57,7 @@
       "type": "spacing"
     },
     "maxHeight": {
-      "value": "{spacing.550.value}",
+      "value": "{spacing.500.value}",
       "type": "sizing"
     },
     "outline": {
@@ -65,6 +69,10 @@
     "padding": {
       "value": "{spacing.75.value} 0 {spacing.75.value} {spacing.150.value}",
       "type": "spacing"
+    },
+    "placeholder": {
+      "value": "{color.grayscale.700.value}",
+      "type": "color"
     }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

To align the search with mandatory elements alignment add tokens for placeholder colour, width and height.


For https://github.com/cds-snc/gcds-components/pull/743