### PR TITLE
fix: Breadcrumb item margins

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1407,7 +1407,7 @@
       "item": {
         "arrow": {
           "margin": {
-            "value": "0 0.75rem 0 0",
+            "value": "0 0.5rem 0 0",
             "type": "spacing"
           }
         },
@@ -1421,7 +1421,7 @@
           "type": "typography"
         },
         "margin": {
-          "value": "0.5rem 0.25rem",
+          "value": "0.5rem 0.25rem 0.5rem 0.125rem",
           "type": "spacing"
         }
       },

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -128,9 +128,9 @@
   --gcds-alert-warning-background: #faedd1;
   --gcds-alert-warning-icon: #b3800f;
   --gcds-alert-warning-text: #333333;
-  --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
   --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;
   --gcds-button-border-radius: 0.375rem;

--- a/build/web/css/components/breadcrumbs.css
+++ b/build/web/css/components/breadcrumbs.css
@@ -3,9 +3,9 @@
  */
 
 :root {
-  --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
   --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -288,9 +288,9 @@
   --gcds-alert-warning-background: #faedd1;
   --gcds-alert-warning-icon: #b3800f;
   --gcds-alert-warning-text: #333333;
-  --gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+  --gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
   --gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
-  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+  --gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
   --gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
   --gcds-breadcrumbs-padding: 0 0 0 0.125rem;
   --gcds-button-border-radius: 0.375rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -126,9 +126,9 @@ $gcds-alert-success-text: #333333;
 $gcds-alert-warning-background: #faedd1;
 $gcds-alert-warning-icon: #b3800f;
 $gcds-alert-warning-text: #333333;
-$gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
 $gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;
 $gcds-button-border-radius: 0.375rem;

--- a/build/web/scss/components/breadcrumbs.scss
+++ b/build/web/scss/components/breadcrumbs.scss
@@ -1,8 +1,8 @@
 
 // Do not edit directly, this file was auto-generated.
 
-$gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
 $gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -286,9 +286,9 @@ $gcds-alert-success-text: #333333;
 $gcds-alert-warning-background: #faedd1;
 $gcds-alert-warning-icon: #b3800f;
 $gcds-alert-warning-text: #333333;
-$gcds-breadcrumbs-item-arrow-margin: 0 0.75rem 0 0;
+$gcds-breadcrumbs-item-arrow-margin: 0 0.5rem 0 0;
 $gcds-breadcrumbs-item-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
-$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem;
+$gcds-breadcrumbs-item-margin: 0.5rem 0.25rem 0.5rem 0.125rem;
 $gcds-breadcrumbs-margin: 0 0 0 -0.125rem;
 $gcds-breadcrumbs-padding: 0 0 0 0.125rem;
 $gcds-button-border-radius: 0.375rem;

--- a/tokens/components/breadcrumbs/tokens.json
+++ b/tokens/components/breadcrumbs/tokens.json
@@ -3,7 +3,7 @@
     "item": {
       "arrow": {
         "margin": {
-          "value": "0 {spacing.150.value} 0 0",
+          "value": "0 {spacing.100.value} 0 0",
           "type": "spacing"
         }
       },
@@ -18,7 +18,7 @@
         "comment": "Mandatory elements alignment: sub-components of header use 16px font"
       },
       "margin": {
-        "value": "{spacing.100.value} {spacing.50.value}",
+        "value": "{spacing.100.value} {spacing.50.value} {spacing.100.value} {spacing.25.value}",
         "type": "spacing"
       }
     },


### PR DESCRIPTION
# Summary | Résumé

For mandatory elements alignment, adjust margins on breadcrumbs item to have a smaller gap between items, from `12px` to `8px`.

For https://github.com/cds-snc/gcds-components/pull/742
