### PR TITLE
feat: add date-modified font token + update margin-top value

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1976,7 +1976,7 @@
         "type": "typography"
       },
       "margin": {
-        "value": "3rem 0 1rem",
+        "value": "2.5rem 0 1rem",
         "type": "spacing"
       }
     },

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1966,6 +1966,15 @@
           "type": "spacing"
         }
       },
+      "font": {
+        "value": {
+          "fontFamily": "'Noto Sans', sans-serif",
+          "fontWeight": "400",
+          "lineHeight": "150%",
+          "fontSize": "1rem"
+        },
+        "type": "typography"
+      },
       "margin": {
         "value": "3rem 0 1rem",
         "type": "spacing"

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -223,7 +223,7 @@
   --gcds-date-input-margin: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
   --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
-  --gcds-date-modified-margin: 3rem 0 1rem;
+  --gcds-date-modified-margin: 2.5rem 0 1rem;
   --gcds-details-default-text: #2b4380;
   --gcds-details-default-decoration-thickness: 0.0625rem;
   --gcds-details-focus-background: #0535d2;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -222,6 +222,7 @@
   --gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-date-input-margin: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
+  --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
   --gcds-date-modified-margin: 3rem 0 1rem;
   --gcds-details-default-text: #2b4380;
   --gcds-details-default-decoration-thickness: 0.0625rem;

--- a/build/web/css/components/date-modified.css
+++ b/build/web/css/components/date-modified.css
@@ -4,5 +4,6 @@
 
 :root {
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
+  --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
   --gcds-date-modified-margin: 3rem 0 1rem;
 }

--- a/build/web/css/components/date-modified.css
+++ b/build/web/css/components/date-modified.css
@@ -5,5 +5,5 @@
 :root {
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
   --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
-  --gcds-date-modified-margin: 3rem 0 1rem;
+  --gcds-date-modified-margin: 2.5rem 0 1rem;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -382,6 +382,7 @@
   --gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-date-input-margin: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
+  --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
   --gcds-date-modified-margin: 3rem 0 1rem;
   --gcds-details-default-text: #2b4380;
   --gcds-details-default-decoration-thickness: 0.0625rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -383,7 +383,7 @@
   --gcds-date-input-margin: 0.75rem;
   --gcds-date-modified-description-margin: 0 0 0 0.125rem;
   --gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font */
-  --gcds-date-modified-margin: 3rem 0 1rem;
+  --gcds-date-modified-margin: 2.5rem 0 1rem;
   --gcds-details-default-text: #2b4380;
   --gcds-details-default-decoration-thickness: 0.0625rem;
   --gcds-details-focus-background: #0535d2;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -221,7 +221,7 @@ $gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-date-input-margin: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
 $gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
-$gcds-date-modified-margin: 3rem 0 1rem;
+$gcds-date-modified-margin: 2.5rem 0 1rem;
 $gcds-details-default-text: #2b4380;
 $gcds-details-default-decoration-thickness: 0.0625rem;
 $gcds-details-focus-background: #0535d2;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -220,6 +220,7 @@ $gcds-date-input-label-font-desktop: 500 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-date-input-margin: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
+$gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
 $gcds-date-modified-margin: 3rem 0 1rem;
 $gcds-details-default-text: #2b4380;
 $gcds-details-default-decoration-thickness: 0.0625rem;

--- a/build/web/scss/components/date-modified.scss
+++ b/build/web/scss/components/date-modified.scss
@@ -2,4 +2,5 @@
 // Do not edit directly, this file was auto-generated.
 
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
+$gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
 $gcds-date-modified-margin: 3rem 0 1rem;

--- a/build/web/scss/components/date-modified.scss
+++ b/build/web/scss/components/date-modified.scss
@@ -3,4 +3,4 @@
 
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
 $gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
-$gcds-date-modified-margin: 3rem 0 1rem;
+$gcds-date-modified-margin: 2.5rem 0 1rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -380,6 +380,7 @@ $gcds-date-input-label-font-desktop: 500 1.25rem/160% 'Noto Sans', sans-serif;
 $gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-date-input-margin: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
+$gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
 $gcds-date-modified-margin: 3rem 0 1rem;
 $gcds-details-default-text: #2b4380;
 $gcds-details-default-decoration-thickness: 0.0625rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -381,7 +381,7 @@ $gcds-date-input-label-font-mobile: 500 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-date-input-margin: 0.75rem;
 $gcds-date-modified-description-margin: 0 0 0 0.125rem;
 $gcds-date-modified-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font
-$gcds-date-modified-margin: 3rem 0 1rem;
+$gcds-date-modified-margin: 2.5rem 0 1rem;
 $gcds-details-default-text: #2b4380;
 $gcds-details-default-decoration-thickness: 0.0625rem;
 $gcds-details-focus-background: #0535d2;

--- a/tokens/components/date-modified/tokens.json
+++ b/tokens/components/date-modified/tokens.json
@@ -17,7 +17,7 @@
       "comment": "Mandatory elements alignment: sub-components of footer use 16px font"
     },
     "margin": {
-      "value": "{spacing.600.value} 0 {spacing.200.value}",
+      "value": "{spacing.500.value} 0 {spacing.200.value}",
       "type": "spacing"
     }
   }

--- a/tokens/components/date-modified/tokens.json
+++ b/tokens/components/date-modified/tokens.json
@@ -6,6 +6,16 @@
         "type": "spacing"
       }
     },
+    "font": {
+      "value": {
+        "fontFamily": "{fontFamilies.body}",
+        "fontWeight": "{fontWeights.regular}",
+        "lineHeight": "{lineHeights.textSmallMobile}",
+        "fontSize": "{fontSizes.textSmallMobile}"
+      },
+      "type": "typography",
+      "comment": "Mandatory elements alignment: sub-components of footer use 16px font"
+    },
     "margin": {
       "value": "{spacing.600.value} 0 {spacing.200.value}",
       "type": "spacing"


### PR DESCRIPTION
# Summary | Résumé

To match the requirements for the alignment of the mandatory elements, add a font token to the date-modified component tokens and update the `margin-top` token to `40px`.

## Requirements

- Date-modified text uses size 16px font since it is a sub-component of the footer.
- Date-modified margin-top is set to 40px.

## Zenhub ticket

The [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1266) for the requested change.