### PR TITLE
feat: add footer font token + update heading font

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2476,6 +2476,15 @@
         }
       },
       "font": {
+        "_": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "400",
+            "lineHeight": "150%",
+            "fontSize": "1rem"
+          },
+          "type": "typography"
+        },
         "heading": {
           "value": {
             "fontFamily": "'Lato', sans-serif",

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2477,24 +2477,31 @@
       },
       "font": {
         "heading": {
-          "desktop": {
-            "value": {
-              "fontFamily": "'Lato', sans-serif",
-              "fontWeight": "700",
-              "lineHeight": "133%",
-              "fontSize": "1.5rem"
-            },
-            "type": "typography"
+          "value": {
+            "fontFamily": "'Lato', sans-serif",
+            "fontWeight": "700",
+            "lineHeight": "123%",
+            "fontSize": "1.625rem"
           },
-          "mobile": {
-            "value": {
-              "fontFamily": "'Lato', sans-serif",
-              "fontWeight": "700",
-              "lineHeight": "127%",
-              "fontSize": "1.375rem"
-            },
-            "type": "typography"
-          }
+          "type": "typography"
+        },
+        "headingDesktop": {
+          "value": {
+            "fontFamily": "'Lato', sans-serif",
+            "fontWeight": "700",
+            "lineHeight": "133%",
+            "fontSize": "1.5rem"
+          },
+          "type": "typography"
+        },
+        "headingMobile": {
+          "value": {
+            "fontFamily": "'Lato', sans-serif",
+            "fontWeight": "700",
+            "lineHeight": "127%",
+            "fontSize": "1.375rem"
+          },
+          "type": "typography"
         }
       },
       "list": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -308,6 +308,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
+  --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -308,8 +308,9 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+  --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
+  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
+  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/build/web/css/components/footer.css
+++ b/build/web/css/components/footer.css
@@ -8,8 +8,9 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+  --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
+  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
+  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/build/web/css/components/footer.css
+++ b/build/web/css/components/footer.css
@@ -8,6 +8,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
+  --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -468,6 +468,7 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
+  --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -468,8 +468,9 @@
   --gcds-footer-contextual-background: #33465c;
   --gcds-footer-contextual-padding: 1.125rem 0;
   --gcds-footer-contextual-text: #ffffff;
-  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+  --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
+  --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
+  --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-list-grid-gap: 0.75rem;
   --gcds-footer-list-padding: 0;
   --gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -306,8 +306,9 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+$gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
+$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
+$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -306,6 +306,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
+$gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request

--- a/build/web/scss/components/footer.scss
+++ b/build/web/scss/components/footer.scss
@@ -6,8 +6,9 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+$gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
+$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
+$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/build/web/scss/components/footer.scss
+++ b/build/web/scss/components/footer.scss
@@ -6,6 +6,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
+$gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -466,6 +466,7 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
+$gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -466,8 +466,9 @@ $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
 $gcds-footer-contextual-padding: 1.125rem 0;
 $gcds-footer-contextual-text: #ffffff;
-$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif;
-$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif;
+$gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
+$gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
+$gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-list-grid-gap: 0.75rem;
 $gcds-footer-list-padding: 0;
 $gcds-footer-listitem-margin: 0 0 0.625rem;

--- a/tokens/components/footer/tokens.json
+++ b/tokens/components/footer/tokens.json
@@ -26,24 +26,34 @@
     },
     "font": {
       "heading": {
-        "desktop": {
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.bold}",
-            "lineHeight": "{lineHeights.h5}",
-            "fontSize": "{fontSizes.h5}"
-          },
-          "type": "typography"
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h3Mobile}",
+          "fontSize": "{fontSizes.h3Mobile}"
         },
-        "mobile": {
-          "value": {
-            "fontFamily": "{fontFamilies.heading}",
-            "fontWeight": "{fontWeights.bold}",
-            "lineHeight": "{lineHeights.h5Mobile}",
-            "fontSize": "{fontSizes.h5Mobile}"
-          },
-          "type": "typography"
-        }
+        "type": "typography",
+        "comment": "Mandatory elements alignment: size 26px"
+      },
+      "headingDesktop": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h5}",
+          "fontSize": "{fontSizes.h5}"
+        },
+        "type": "typography",
+        "comment": "Will be removed in separate pull request"
+      },
+      "headingMobile": {
+        "value": {
+          "fontFamily": "{fontFamilies.heading}",
+          "fontWeight": "{fontWeights.bold}",
+          "lineHeight": "{lineHeights.h5Mobile}",
+          "fontSize": "{fontSizes.h5Mobile}"
+        },
+        "type": "typography",
+        "comment": "Will be removed in separate pull request"
       }
     },
     "list": {

--- a/tokens/components/footer/tokens.json
+++ b/tokens/components/footer/tokens.json
@@ -25,6 +25,16 @@
       }
     },
     "font": {
+      "_": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.regular}",
+          "lineHeight": "{lineHeights.textSmallMobile}",
+          "fontSize": "{fontSizes.textSmallMobile}"
+        },
+        "type": "typography",
+        "comment": "Mandatory elements alignment: sub-components of footer use 16px font."
+      },
       "heading": {
         "value": {
           "fontFamily": "{fontFamilies.heading}",


### PR DESCRIPTION
# Summary | Résumé

To match the requirements for the alignment of the mandatory elements, the heading font of the footer component needs to be updated and a new footer font token needs to be added.

## Requirements

- Heading fonts remain set to Lato, and non-heading fonts remain set to Noto
- Headings should be H3 and should be the mobile sizing ( font-size: 26px or 1.625rem, line-height: 30px or 2rem)
- Heading font weights remain set to 700
- Link size is set to 16px (1rem) on desktop to align with Canada.ca
- Link size is set to 16px (1rem) on mobile to align with Canada.ca

## Zenhub ticket

The [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1266) for the requested change.

## Note

I will remove the old `--gcds-footer-font-heading-desktop` and `--gcds-footer-font-heading-mobile` in a separate PR.
