### PR TITLE
refactor: update footer spacing tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -2460,6 +2460,12 @@
       }
     },
     "footer": {
+      "band": {
+        "padding": {
+          "value": "2.25rem 0",
+          "type": "spacing"
+        }
+      },
       "container": {
         "margin": {
           "value": "0 auto",
@@ -2520,6 +2526,16 @@
             "fontSize": "1.375rem"
           },
           "type": "typography"
+        }
+      },
+      "gridGap": {
+        "value": "1.5rem",
+        "type": "spacing"
+      },
+      "heading": {
+        "margin": {
+          "value": "0 0 1.5rem",
+          "type": "spacing"
         }
       },
       "list": {
@@ -2606,7 +2622,7 @@
         "signature": {
           "lg": {
             "width": {
-              "value": "10.937rem",
+              "value": "10.25rem",
               "type": "sizing"
             },
             "minWidth": {
@@ -2618,9 +2634,31 @@
               "type": "spacing"
             }
           },
+          "width": {
+            "value": "10.25rem",
+            "type": "sizing"
+          },
+          "minWidth": {
+            "value": "auto",
+            "type": "sizing"
+          },
+          "maxHeight": {
+            "value": "2.4375rem",
+            "type": "sizing"
+          },
           "margin": {
-            "value": "2.25rem 0 3.75rem auto",
+            "value": "0 0 0 auto",
             "type": "spacing"
+          },
+          "sm": {
+            "width": {
+              "value": "6.25rem",
+              "type": "sizing"
+            },
+            "maxHeight": {
+              "value": "1.5rem",
+              "type": "sizing"
+            }
           }
         },
         "md": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -304,35 +304,43 @@
   --gcds-file-uploader-hover-button-background: #d7e5f5;
   --gcds-file-uploader-active-button-background: #000000;
   --gcds-file-uploader-active-button-text: #ffffff;
+  --gcds-footer-band-padding: 2.25rem 0;
   --gcds-footer-container-margin: 0 auto;
   --gcds-footer-container-width: 71.25rem;
   --gcds-footer-contextual-background: #33465c;
-  --gcds-footer-contextual-padding: 1.125rem 0;
+  --gcds-footer-contextual-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-contextual-text: #ffffff;
   --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
-  --gcds-footer-list-grid-gap: 0.75rem;
+  --gcds-footer-grid-gap: 1.5rem;
+  --gcds-footer-heading-margin: 0 0 1.5rem;
+  --gcds-footer-list-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-list-padding: 0;
-  --gcds-footer-listitem-margin: 0 0 0.625rem;
+  --gcds-footer-listitem-margin: 0 0 0.625rem; /* Will be removed in separate pull request */
   --gcds-footer-main-background: #26374a;
-  --gcds-footer-main-govnav-padding: 1.125rem 0;
+  --gcds-footer-main-govnav-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-main-nav-first-after-border-color: #ffffff;
   --gcds-footer-main-nav-first-after-border-width: 0.25rem;
   --gcds-footer-main-nav-first-after-width: 2.25rem;
   --gcds-footer-main-text: #ffffff;
-  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-background: #f1f2f3;
-  --gcds-footer-sub-grid-gap: 0.75rem;
+  --gcds-footer-sub-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-  --gcds-footer-sub-nav-padding: 2.75rem 0;
-  --gcds-footer-sub-signature-lg-width: 10.937rem;
-  --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-  --gcds-footer-sub-md-width: 7rem;
-  --gcds-footer-sub-sm-width: 100%;
+  --gcds-footer-sub-nav-padding: 2.75rem 0; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-width: 10.25rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-min-width: auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-width: 10.25rem;
+  --gcds-footer-sub-signature-min-width: auto;
+  --gcds-footer-sub-signature-max-height: 2.4375rem;
+  --gcds-footer-sub-signature-margin: 0 0 0 auto;
+  --gcds-footer-sub-signature-sm-width: 6.25rem;
+  --gcds-footer-sub-signature-sm-max-height: 1.5rem;
+  --gcds-footer-sub-md-width: 7rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-sm-width: 100%; /* Will be removed in separate pull request */
   --gcds-grid-columns-default-base: 1;
   --gcds-grid-columns-default-tablet: 6;
   --gcds-grid-columns-default-desktop: 12;

--- a/build/web/css/components/footer.css
+++ b/build/web/css/components/footer.css
@@ -3,33 +3,41 @@
  */
 
 :root {
+  --gcds-footer-band-padding: 2.25rem 0;
   --gcds-footer-container-margin: 0 auto;
   --gcds-footer-container-width: 71.25rem;
   --gcds-footer-contextual-background: #33465c;
-  --gcds-footer-contextual-padding: 1.125rem 0;
+  --gcds-footer-contextual-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-contextual-text: #ffffff;
   --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
-  --gcds-footer-list-grid-gap: 0.75rem;
+  --gcds-footer-grid-gap: 1.5rem;
+  --gcds-footer-heading-margin: 0 0 1.5rem;
+  --gcds-footer-list-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-list-padding: 0;
-  --gcds-footer-listitem-margin: 0 0 0.625rem;
+  --gcds-footer-listitem-margin: 0 0 0.625rem; /* Will be removed in separate pull request */
   --gcds-footer-main-background: #26374a;
-  --gcds-footer-main-govnav-padding: 1.125rem 0;
+  --gcds-footer-main-govnav-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-main-nav-first-after-border-color: #ffffff;
   --gcds-footer-main-nav-first-after-border-width: 0.25rem;
   --gcds-footer-main-nav-first-after-width: 2.25rem;
   --gcds-footer-main-text: #ffffff;
-  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-background: #f1f2f3;
-  --gcds-footer-sub-grid-gap: 0.75rem;
+  --gcds-footer-sub-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-  --gcds-footer-sub-nav-padding: 2.75rem 0;
-  --gcds-footer-sub-signature-lg-width: 10.937rem;
-  --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-  --gcds-footer-sub-md-width: 7rem;
-  --gcds-footer-sub-sm-width: 100%;
+  --gcds-footer-sub-nav-padding: 2.75rem 0; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-width: 10.25rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-min-width: auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-width: 10.25rem;
+  --gcds-footer-sub-signature-min-width: auto;
+  --gcds-footer-sub-signature-max-height: 2.4375rem;
+  --gcds-footer-sub-signature-margin: 0 0 0 auto;
+  --gcds-footer-sub-signature-sm-width: 6.25rem;
+  --gcds-footer-sub-signature-sm-max-height: 1.5rem;
+  --gcds-footer-sub-md-width: 7rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-sm-width: 100%; /* Will be removed in separate pull request */
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -464,35 +464,43 @@
   --gcds-file-uploader-hover-button-background: #d7e5f5;
   --gcds-file-uploader-active-button-background: #000000;
   --gcds-file-uploader-active-button-text: #ffffff;
+  --gcds-footer-band-padding: 2.25rem 0;
   --gcds-footer-container-margin: 0 auto;
   --gcds-footer-container-width: 71.25rem;
   --gcds-footer-contextual-background: #33465c;
-  --gcds-footer-contextual-padding: 1.125rem 0;
+  --gcds-footer-contextual-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-contextual-text: #ffffff;
   --gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of footer use 16px font. */
   --gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; /* Mandatory elements alignment: size 26px */
   --gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; /* Will be removed in separate pull request */
   --gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; /* Will be removed in separate pull request */
-  --gcds-footer-list-grid-gap: 0.75rem;
+  --gcds-footer-grid-gap: 1.5rem;
+  --gcds-footer-heading-margin: 0 0 1.5rem;
+  --gcds-footer-list-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-list-padding: 0;
-  --gcds-footer-listitem-margin: 0 0 0.625rem;
+  --gcds-footer-listitem-margin: 0 0 0.625rem; /* Will be removed in separate pull request */
   --gcds-footer-main-background: #26374a;
-  --gcds-footer-main-govnav-padding: 1.125rem 0;
+  --gcds-footer-main-govnav-padding: 1.125rem 0; /* Will be removed in separate pull request */
   --gcds-footer-main-nav-first-after-border-color: #ffffff;
   --gcds-footer-main-nav-first-after-border-width: 0.25rem;
   --gcds-footer-main-nav-first-after-width: 2.25rem;
   --gcds-footer-main-text: #ffffff;
-  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+  --gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-background: #f1f2f3;
-  --gcds-footer-sub-grid-gap: 0.75rem;
+  --gcds-footer-sub-grid-gap: 0.75rem; /* Will be removed in separate pull request */
   --gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-  --gcds-footer-sub-nav-padding: 2.75rem 0;
-  --gcds-footer-sub-signature-lg-width: 10.937rem;
-  --gcds-footer-sub-signature-lg-min-width: auto;
-  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-  --gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-  --gcds-footer-sub-md-width: 7rem;
-  --gcds-footer-sub-sm-width: 100%;
+  --gcds-footer-sub-nav-padding: 2.75rem 0; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-width: 10.25rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-min-width: auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; /* Will be removed in separate pull request */
+  --gcds-footer-sub-signature-width: 10.25rem;
+  --gcds-footer-sub-signature-min-width: auto;
+  --gcds-footer-sub-signature-max-height: 2.4375rem;
+  --gcds-footer-sub-signature-margin: 0 0 0 auto;
+  --gcds-footer-sub-signature-sm-width: 6.25rem;
+  --gcds-footer-sub-signature-sm-max-height: 1.5rem;
+  --gcds-footer-sub-md-width: 7rem; /* Will be removed in separate pull request */
+  --gcds-footer-sub-sm-width: 100%; /* Will be removed in separate pull request */
   --gcds-grid-columns-default-base: 1;
   --gcds-grid-columns-default-tablet: 6;
   --gcds-grid-columns-default-desktop: 12;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -302,35 +302,43 @@ $gcds-file-uploader-focus-button-outline-offset: 0.125rem;
 $gcds-file-uploader-hover-button-background: #d7e5f5;
 $gcds-file-uploader-active-button-background: #000000;
 $gcds-file-uploader-active-button-text: #ffffff;
+$gcds-footer-band-padding: 2.25rem 0;
 $gcds-footer-container-margin: 0 auto;
 $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
-$gcds-footer-contextual-padding: 1.125rem 0;
+$gcds-footer-contextual-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-contextual-text: #ffffff;
 $gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
-$gcds-footer-list-grid-gap: 0.75rem;
+$gcds-footer-grid-gap: 1.5rem;
+$gcds-footer-heading-margin: 0 0 1.5rem;
+$gcds-footer-list-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-list-padding: 0;
-$gcds-footer-listitem-margin: 0 0 0.625rem;
+$gcds-footer-listitem-margin: 0 0 0.625rem; // Will be removed in separate pull request
 $gcds-footer-main-background: #26374a;
-$gcds-footer-main-govnav-padding: 1.125rem 0;
+$gcds-footer-main-govnav-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-main-nav-first-after-border-color: #ffffff;
 $gcds-footer-main-nav-first-after-border-width: 0.25rem;
 $gcds-footer-main-nav-first-after-width: 2.25rem;
 $gcds-footer-main-text: #ffffff;
-$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; // Will be removed in separate pull request
 $gcds-footer-sub-background: #f1f2f3;
-$gcds-footer-sub-grid-gap: 0.75rem;
+$gcds-footer-sub-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-$gcds-footer-sub-nav-padding: 2.75rem 0;
-$gcds-footer-sub-signature-lg-width: 10.937rem;
-$gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-$gcds-footer-sub-md-width: 7rem;
-$gcds-footer-sub-sm-width: 100%;
+$gcds-footer-sub-nav-padding: 2.75rem 0; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-width: 10.25rem; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-min-width: auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-width: 10.25rem;
+$gcds-footer-sub-signature-min-width: auto;
+$gcds-footer-sub-signature-max-height: 2.4375rem;
+$gcds-footer-sub-signature-margin: 0 0 0 auto;
+$gcds-footer-sub-signature-sm-width: 6.25rem;
+$gcds-footer-sub-signature-sm-max-height: 1.5rem;
+$gcds-footer-sub-md-width: 7rem; // Will be removed in separate pull request
+$gcds-footer-sub-sm-width: 100%; // Will be removed in separate pull request
 $gcds-grid-columns-default-base: 1;
 $gcds-grid-columns-default-tablet: 6;
 $gcds-grid-columns-default-desktop: 12;

--- a/build/web/scss/components/footer.scss
+++ b/build/web/scss/components/footer.scss
@@ -1,32 +1,40 @@
 
 // Do not edit directly, this file was auto-generated.
 
+$gcds-footer-band-padding: 2.25rem 0;
 $gcds-footer-container-margin: 0 auto;
 $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
-$gcds-footer-contextual-padding: 1.125rem 0;
+$gcds-footer-contextual-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-contextual-text: #ffffff;
 $gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
-$gcds-footer-list-grid-gap: 0.75rem;
+$gcds-footer-grid-gap: 1.5rem;
+$gcds-footer-heading-margin: 0 0 1.5rem;
+$gcds-footer-list-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-list-padding: 0;
-$gcds-footer-listitem-margin: 0 0 0.625rem;
+$gcds-footer-listitem-margin: 0 0 0.625rem; // Will be removed in separate pull request
 $gcds-footer-main-background: #26374a;
-$gcds-footer-main-govnav-padding: 1.125rem 0;
+$gcds-footer-main-govnav-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-main-nav-first-after-border-color: #ffffff;
 $gcds-footer-main-nav-first-after-border-width: 0.25rem;
 $gcds-footer-main-nav-first-after-width: 2.25rem;
 $gcds-footer-main-text: #ffffff;
-$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; // Will be removed in separate pull request
 $gcds-footer-sub-background: #f1f2f3;
-$gcds-footer-sub-grid-gap: 0.75rem;
+$gcds-footer-sub-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-$gcds-footer-sub-nav-padding: 2.75rem 0;
-$gcds-footer-sub-signature-lg-width: 10.937rem;
-$gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-$gcds-footer-sub-md-width: 7rem;
-$gcds-footer-sub-sm-width: 100%;
+$gcds-footer-sub-nav-padding: 2.75rem 0; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-width: 10.25rem; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-min-width: auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-width: 10.25rem;
+$gcds-footer-sub-signature-min-width: auto;
+$gcds-footer-sub-signature-max-height: 2.4375rem;
+$gcds-footer-sub-signature-margin: 0 0 0 auto;
+$gcds-footer-sub-signature-sm-width: 6.25rem;
+$gcds-footer-sub-signature-sm-max-height: 1.5rem;
+$gcds-footer-sub-md-width: 7rem; // Will be removed in separate pull request
+$gcds-footer-sub-sm-width: 100%; // Will be removed in separate pull request

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -462,35 +462,43 @@ $gcds-file-uploader-focus-button-outline-offset: 0.125rem;
 $gcds-file-uploader-hover-button-background: #d7e5f5;
 $gcds-file-uploader-active-button-background: #000000;
 $gcds-file-uploader-active-button-text: #ffffff;
+$gcds-footer-band-padding: 2.25rem 0;
 $gcds-footer-container-margin: 0 auto;
 $gcds-footer-container-width: 71.25rem;
 $gcds-footer-contextual-background: #33465c;
-$gcds-footer-contextual-padding: 1.125rem 0;
+$gcds-footer-contextual-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-contextual-text: #ffffff;
 $gcds-footer-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of footer use 16px font.
 $gcds-footer-font-heading: 700 1.625rem/123% 'Lato', sans-serif; // Mandatory elements alignment: size 26px
 $gcds-footer-font-heading-desktop: 700 1.5rem/133% 'Lato', sans-serif; // Will be removed in separate pull request
 $gcds-footer-font-heading-mobile: 700 1.375rem/127% 'Lato', sans-serif; // Will be removed in separate pull request
-$gcds-footer-list-grid-gap: 0.75rem;
+$gcds-footer-grid-gap: 1.5rem;
+$gcds-footer-heading-margin: 0 0 1.5rem;
+$gcds-footer-list-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-list-padding: 0;
-$gcds-footer-listitem-margin: 0 0 0.625rem;
+$gcds-footer-listitem-margin: 0 0 0.625rem; // Will be removed in separate pull request
 $gcds-footer-main-background: #26374a;
-$gcds-footer-main-govnav-padding: 1.125rem 0;
+$gcds-footer-main-govnav-padding: 1.125rem 0; // Will be removed in separate pull request
 $gcds-footer-main-nav-first-after-border-color: #ffffff;
 $gcds-footer-main-nav-first-after-border-width: 0.25rem;
 $gcds-footer-main-nav-first-after-width: 2.25rem;
 $gcds-footer-main-text: #ffffff;
-$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem;
+$gcds-footer-main-themenav-padding: 0.75rem 0 1.125rem; // Will be removed in separate pull request
 $gcds-footer-sub-background: #f1f2f3;
-$gcds-footer-sub-grid-gap: 0.75rem;
+$gcds-footer-sub-grid-gap: 0.75rem; // Will be removed in separate pull request
 $gcds-footer-sub-listitem-before-margin: 0 1.125rem;
-$gcds-footer-sub-nav-padding: 2.75rem 0;
-$gcds-footer-sub-signature-lg-width: 10.937rem;
-$gcds-footer-sub-signature-lg-min-width: auto;
-$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto;
-$gcds-footer-sub-signature-margin: 2.25rem 0 3.75rem auto;
-$gcds-footer-sub-md-width: 7rem;
-$gcds-footer-sub-sm-width: 100%;
+$gcds-footer-sub-nav-padding: 2.75rem 0; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-width: 10.25rem; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-min-width: auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-lg-margin: 2.25rem 0 2.25rem auto; // Will be removed in separate pull request
+$gcds-footer-sub-signature-width: 10.25rem;
+$gcds-footer-sub-signature-min-width: auto;
+$gcds-footer-sub-signature-max-height: 2.4375rem;
+$gcds-footer-sub-signature-margin: 0 0 0 auto;
+$gcds-footer-sub-signature-sm-width: 6.25rem;
+$gcds-footer-sub-signature-sm-max-height: 1.5rem;
+$gcds-footer-sub-md-width: 7rem; // Will be removed in separate pull request
+$gcds-footer-sub-sm-width: 100%; // Will be removed in separate pull request
 $gcds-grid-columns-default-base: 1;
 $gcds-grid-columns-default-tablet: 6;
 $gcds-grid-columns-default-desktop: 12;

--- a/tokens/components/footer/tokens.json
+++ b/tokens/components/footer/tokens.json
@@ -1,5 +1,11 @@
 {
   "footer": {
+    "band": {
+      "padding": {
+        "value": "{spacing.450.value} 0",
+        "type": "spacing"
+      }
+    },
     "container": {
       "margin": {
         "value": "0 auto",
@@ -17,7 +23,8 @@
       },
       "padding": {
         "value": "{spacing.225.value} 0",
-        "type": "spacing"
+        "type": "spacing",
+        "comment": "Will be removed in separate pull request"
       },
       "text": {
         "value": "{text.light.value}",
@@ -66,10 +73,21 @@
         "comment": "Will be removed in separate pull request"
       }
     },
+    "gridGap": {
+      "value": "{spacing.300.value}",
+      "type": "spacing"
+    },
+    "heading": {
+      "margin": {
+        "value": "0 0 {spacing.300.value}",
+        "type": "spacing"
+      }
+    },
     "list": {
       "gridGap": {
         "value": "{spacing.150.value}",
-        "type": "spacing"
+        "type": "spacing",
+        "comment": "Will be removed in separate pull request"
       },
       "padding": {
         "value": "0",
@@ -79,7 +97,8 @@
     "listitem": {
       "margin": {
         "value": "0 0 {spacing.125.value}",
-        "type": "spacing"
+        "type": "spacing",
+        "comment": "Will be removed in separate pull request"
       }
     },
     "main": {
@@ -90,7 +109,8 @@
       "govnav": {
         "padding": {
           "value": "{spacing.225.value} 0",
-          "type": "spacing"
+          "type": "spacing",
+          "comment": "Will be removed in separate pull request"
         }
       },
       "nav": {
@@ -120,7 +140,8 @@
       "themenav": {
         "padding": {
           "value": "{spacing.150.value} 0 {spacing.225.value}",
-          "type": "spacing"
+          "type": "spacing",
+          "comment": "Will be removed in separate pull request"
         }
       }
     },
@@ -131,7 +152,8 @@
       },
       "gridGap": {
         "value": "{spacing.150.value}",
-        "type": "spacing"
+        "type": "spacing",
+        "comment": "Will be removed in separate pull request"
       },
       "listitem": {
         "before": {
@@ -144,39 +166,67 @@
       "nav": {
         "padding": {
           "value": "{spacing.550.value} 0",
-          "type": "spacing"
+          "type": "spacing",
+          "comment": "Will be removed in separate pull request"
         }
       },
       "signature": {
         "lg": {
           "width": {
-            "value": "10.937rem",
-            "type": "sizing"
+            "value": "10.25rem",
+            "type": "sizing",
+            "comment": "Will be removed in separate pull request"
           },
           "minWidth": {
             "value": "auto",
-            "type": "sizing"
+            "type": "sizing",
+            "comment": "Will be removed in separate pull request"
           },
           "margin": {
             "value": "{spacing.450.value} 0 {spacing.450.value} auto",
-            "type": "spacing"
+            "type": "spacing",
+            "comment": "Will be removed in separate pull request"
           }
         },
+        "width": {
+          "value": "10.25rem",
+          "type": "sizing"
+        },
+        "minWidth": {
+          "value": "auto",
+          "type": "sizing"
+        },
+        "maxHeight": {
+          "value": "2.4375rem",
+          "type": "sizing"
+        },
         "margin": {
-          "value": "{spacing.450.value} 0 {spacing.750.value} auto",
+          "value": "0 0 0 auto",
           "type": "spacing"
+        },
+        "sm": {
+          "width": {
+            "value": "6.25rem",
+            "type": "sizing"
+          },
+          "maxHeight": {
+            "value": "1.5rem",
+            "type": "sizing"
+          }
         }
       },
       "md": {
         "width": {
           "value": "7rem",
-          "type": "sizing"
+          "type": "sizing",
+          "comment": "Will be removed in separate pull request"
         }
       },
       "sm": {
         "width": {
           "value": "{container.full.value}",
-          "type": "sizing"
+          "type": "sizing",
+          "comment": "Will be removed in separate pull request"
         }
       }
     }


### PR DESCRIPTION
# Summary | Résumé

Updating the footer spacing to align with the new design. The new design introduces a bit more consistency in the spacing, especially for the following 3 things:

- Consistent margin bottom value for headings (`spacing-300`)
- Consistent grid gap spacing for all lists (`spacing-300`)
- Consistent band padding for all 2 bands: contextual, main & sub (`spacing-450`)

For the signature width tokens, I noticed that the naming of the token could be optimized. For example, the old signature token `--gcds-footer-sub-sm-width` is now named `--gcds-footer-sub-signature-sm-width` to create a clear connection between the token and the signature.

## Note

As part of this refactor, many of the old padding & margin tokens are no longer used. I will remove them in a separate PR.