### PR TITLE
fix: maintain focus style for search

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -4262,11 +4262,19 @@
           "color": {
             "value": "#0535d2",
             "type": "color"
+          },
+          "width": {
+            "value": "0.125rem",
+            "type": "borderWidth"
           }
         },
         "boxShadow": {
           "value": "0 0 0 0.125rem #FFF",
           "type": "other"
+        },
+        "margin": {
+          "value": "0 -0.125rem 0 0",
+          "type": "spacing"
         }
       },
       "font": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -639,7 +639,9 @@
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
+  --gcds-search-focus-border-width: 0.125rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+  --gcds-search-focus-margin: 0 -0.125rem 0 0;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
   --gcds-search-max-height: 2.5rem;

--- a/build/web/css/components/search.css
+++ b/build/web/css/components/search.css
@@ -10,7 +10,9 @@
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
+  --gcds-search-focus-border-width: 0.125rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+  --gcds-search-focus-margin: 0 -0.125rem 0 0;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
   --gcds-search-max-height: 2.5rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -799,7 +799,9 @@
   --gcds-search-default-background: #ffffff;
   --gcds-search-default-text: #333333;
   --gcds-search-focus-border-color: #0535d2;
+  --gcds-search-focus-border-width: 0.125rem;
   --gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+  --gcds-search-focus-margin: 0 -0.125rem 0 0;
   --gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; /* Mandatory elements alignment: sub-components of header use 16px font */
   --gcds-search-margin: 0 0 0.125rem;
   --gcds-search-max-height: 2.5rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -637,7 +637,9 @@ $gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
+$gcds-search-focus-border-width: 0.125rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+$gcds-search-focus-margin: 0 -0.125rem 0 0;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
 $gcds-search-max-height: 2.5rem;

--- a/build/web/scss/components/search.scss
+++ b/build/web/scss/components/search.scss
@@ -8,7 +8,9 @@ $gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
+$gcds-search-focus-border-width: 0.125rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+$gcds-search-focus-margin: 0 -0.125rem 0 0;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
 $gcds-search-max-height: 2.5rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -797,7 +797,9 @@ $gcds-search-button-width-height: 2.5rem;
 $gcds-search-default-background: #ffffff;
 $gcds-search-default-text: #333333;
 $gcds-search-focus-border-color: #0535d2;
+$gcds-search-focus-border-width: 0.125rem;
 $gcds-search-focus-box-shadow: 0 0 0 0.125rem #ffffff;
+$gcds-search-focus-margin: 0 -0.125rem 0 0;
 $gcds-search-font: 400 1rem/150% 'Noto Sans', sans-serif; // Mandatory elements alignment: sub-components of header use 16px font
 $gcds-search-margin: 0 0 0.125rem;
 $gcds-search-max-height: 2.5rem;

--- a/tokens/components/search/tokens.json
+++ b/tokens/components/search/tokens.json
@@ -35,11 +35,19 @@
         "color": {
           "value": "{focus.border.value}",
           "type": "color"
+        },
+        "width": {
+          "value": "{border.width.md.value}",
+          "type": "borderWidth"
         }
       },
       "boxShadow": {
         "value": "0 0 0 {border.width.md.value} {focus.text.value}",
         "type": "other"
+      },
+      "margin": {
+        "value": "0 -{border.width.md.value} 0 0",
+        "type": "spacing"
       }
     },
     "font": {


### PR DESCRIPTION
# Summary | Résumé

To maintain the visual focus style used on search and keep it aligned with other components in the GC Design System, add a focus border and margin tokens. Used border width for the margin token to directly tie the margin to the border size.

For review feedback from https://github.com/cds-snc/gcds-components/pull/743
