### PR TITLE
feat: Start button component tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -81,6 +81,10 @@
         "700": {
           "value": "#03662A",
           "type": "color"
+        },
+        "800": {
+          "value": "#023b1a",
+          "type": "color"
         }
       },
       "purple": {
@@ -1464,16 +1468,36 @@
         }
       },
       "font": {
-        "value": {
-          "fontFamily": "'Noto Sans', sans-serif",
-          "fontWeight": "500",
-          "lineHeight": "140%",
-          "fontSize": "1.25rem"
+        "-": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
         },
-        "type": "typography"
+        "desktop": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
+        },
+        "mobile": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.125rem"
+          },
+          "type": "typography"
+        }
       },
       "padding": {
-        "value": "0.625rem 0.75rem",
+        "value": "0.625rem 1rem",
         "type": "spacing"
       },
       "primary": {
@@ -1567,21 +1591,87 @@
           "text": {
             "value": "#545961",
             "type": "color"
+          },
+          "opacity": {
+            "value": "50%",
+            "type": "other"
           }
         }
       },
       "small": {
         "font": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "400",
-            "lineHeight": "160%",
-            "fontSize": "80%"
+          "-": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "160%",
+              "fontSize": "80%"
+            },
+            "type": "typography"
           },
-          "type": "typography"
+          "desktop": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "155%",
+              "fontSize": "1.125rem"
+            },
+            "type": "typography"
+          },
+          "mobile": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "150%",
+              "fontSize": "1rem"
+            },
+            "type": "typography"
+          }
         },
         "padding": {
-          "value": "0.75rem",
+          "value": "0.375rem 1rem",
+          "type": "spacing"
+        }
+      },
+      "start": {
+        "default": {
+          "background": {
+            "value": "#03662A",
+            "type": "color"
+          },
+          "text": {
+            "value": "#FFF",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "background": {
+            "value": "#023b1a",
+            "type": "color"
+          }
+        },
+        "font": {
+          "desktop": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "600",
+              "lineHeight": "145%",
+              "fontSize": "1.375rem"
+            },
+            "type": "typography"
+          },
+          "mobile": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "500",
+              "lineHeight": "140%",
+              "fontSize": "1.25rem"
+            },
+            "type": "typography"
+          }
+        },
+        "padding": {
+          "value": "0.75rem 2rem",
           "type": "spacing"
         }
       },

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -81,6 +81,10 @@
         "700": {
           "value": "#03662A",
           "type": "color"
+        },
+        "800": {
+          "value": "#023b1a",
+          "type": "color"
         }
       },
       "purple": {
@@ -1464,16 +1468,36 @@
         }
       },
       "font": {
-        "value": {
-          "fontFamily": "'Noto Sans', sans-serif",
-          "fontWeight": "500",
-          "lineHeight": "140%",
-          "fontSize": "1.25rem"
+        "-": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
         },
-        "type": "typography"
+        "desktop": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.25rem"
+          },
+          "type": "typography"
+        },
+        "mobile": {
+          "value": {
+            "fontFamily": "'Noto Sans', sans-serif",
+            "fontWeight": "500",
+            "lineHeight": "140%",
+            "fontSize": "1.125rem"
+          },
+          "type": "typography"
+        }
       },
       "padding": {
-        "value": "0.625rem 0.75rem",
+        "value": "0.625rem 1rem",
         "type": "spacing"
       },
       "primary": {
@@ -1567,21 +1591,87 @@
           "text": {
             "value": "#545961",
             "type": "color"
+          },
+          "opacity": {
+            "value": "50%",
+            "type": "other"
           }
         }
       },
       "small": {
         "font": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "400",
-            "lineHeight": "160%",
-            "fontSize": "80%"
+          "-": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "160%",
+              "fontSize": "80%"
+            },
+            "type": "typography"
           },
-          "type": "typography"
+          "desktop": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "155%",
+              "fontSize": "1.125rem"
+            },
+            "type": "typography"
+          },
+          "mobile": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "400",
+              "lineHeight": "150%",
+              "fontSize": "1rem"
+            },
+            "type": "typography"
+          }
         },
         "padding": {
-          "value": "0.75rem",
+          "value": "0.375rem 1rem",
+          "type": "spacing"
+        }
+      },
+      "start": {
+        "default": {
+          "background": {
+            "value": "#03662A",
+            "type": "color"
+          },
+          "text": {
+            "value": "#FFF",
+            "type": "color"
+          }
+        },
+        "hover": {
+          "background": {
+            "value": "#023b1a",
+            "type": "color"
+          }
+        },
+        "font": {
+          "desktop": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "600",
+              "lineHeight": "145%",
+              "fontSize": "1.375rem"
+            },
+            "type": "typography"
+          },
+          "mobile": {
+            "value": {
+              "fontFamily": "'Noto Sans', sans-serif",
+              "fontWeight": "500",
+              "lineHeight": "140%",
+              "fontSize": "1.25rem"
+            },
+            "type": "typography"
+          }
+        },
+        "padding": {
+          "value": "0.75rem 2rem",
           "type": "spacing"
         }
       },

--- a/build/web/css/base.css
+++ b/build/web/css/base.css
@@ -22,6 +22,7 @@
   --gcds-color-green-100: #e6f6ec;
   --gcds-color-green-500: #289f58; /* Must contrast 3:1 with white */
   --gcds-color-green-700: #03662a; /* Must contrast 7:1 with white */
+  --gcds-color-green-800: #023b1a;
   --gcds-color-purple-700: #7532b8; /* Must contrast 7:1 with white */
   --gcds-color-orange-700: #be5a00; /* Must contrast 7:1 with white */
   --gcds-color-red-100: #fbddda;

--- a/build/web/css/base/color.css
+++ b/build/web/css/base/color.css
@@ -22,6 +22,7 @@
   --gcds-color-green-100: #e6f6ec;
   --gcds-color-green-500: #289f58; /* Must contrast 3:1 with white */
   --gcds-color-green-700: #03662a; /* Must contrast 7:1 with white */
+  --gcds-color-green-800: #023b1a;
   --gcds-color-purple-700: #7532b8; /* Must contrast 7:1 with white */
   --gcds-color-orange-700: #be5a00; /* Must contrast 7:1 with white */
   --gcds-color-red-100: #fbddda;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -138,8 +138,10 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-  --gcds-button-padding: 0.625rem 0.75rem;
+  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-padding: 0.625rem 1rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
   --gcds-button-primary-hover-background: #2b4380;
@@ -155,10 +157,19 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd;
-  --gcds-button-shared-disabled-text: #545961;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-  --gcds-button-small-padding: 0.75rem;
+  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-opacity: 50%;
+  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+  --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-button-small-padding: 0.375rem 1rem;
+  --gcds-button-start-default-background: #03662a;
+  --gcds-button-start-default-text: #ffffff;
+  --gcds-button-start-hover-background: #023b1a;
+  --gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+  --gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-start-padding: 0.75rem 2rem;
   --gcds-button-width: fit-content;
   --gcds-card-background-color: #ffffff;
   --gcds-card-box-shadow: 0 0.125rem 0.5rem 0.125rem #00000019;

--- a/build/web/css/components/button.css
+++ b/build/web/css/components/button.css
@@ -8,8 +8,10 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-  --gcds-button-padding: 0.625rem 0.75rem;
+  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-padding: 0.625rem 1rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
   --gcds-button-primary-hover-background: #2b4380;
@@ -25,9 +27,18 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd;
-  --gcds-button-shared-disabled-text: #545961;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-  --gcds-button-small-padding: 0.75rem;
+  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-opacity: 50%;
+  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+  --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-button-small-padding: 0.375rem 1rem;
+  --gcds-button-start-default-background: #03662a;
+  --gcds-button-start-default-text: #ffffff;
+  --gcds-button-start-hover-background: #023b1a;
+  --gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+  --gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-start-padding: 0.75rem 2rem;
   --gcds-button-width: fit-content;
 }

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -22,6 +22,7 @@
   --gcds-color-green-100: #e6f6ec;
   --gcds-color-green-500: #289f58; /* Must contrast 3:1 with white */
   --gcds-color-green-700: #03662a; /* Must contrast 7:1 with white */
+  --gcds-color-green-800: #023b1a;
   --gcds-color-purple-700: #7532b8; /* Must contrast 7:1 with white */
   --gcds-color-orange-700: #be5a00; /* Must contrast 7:1 with white */
   --gcds-color-red-100: #fbddda;
@@ -298,8 +299,10 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-  --gcds-button-padding: 0.625rem 0.75rem;
+  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-padding: 0.625rem 1rem;
   --gcds-button-primary-default-background: #26374a;
   --gcds-button-primary-default-text: #ffffff;
   --gcds-button-primary-hover-background: #2b4380;
@@ -315,10 +318,19 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd;
-  --gcds-button-shared-disabled-text: #545961;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-  --gcds-button-small-padding: 0.75rem;
+  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
+  --gcds-button-shared-disabled-opacity: 50%;
+  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
+  --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+  --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+  --gcds-button-small-padding: 0.375rem 1rem;
+  --gcds-button-start-default-background: #03662a;
+  --gcds-button-start-default-text: #ffffff;
+  --gcds-button-start-hover-background: #023b1a;
+  --gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+  --gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+  --gcds-button-start-padding: 0.75rem 2rem;
   --gcds-button-width: fit-content;
   --gcds-card-background-color: #ffffff;
   --gcds-card-box-shadow: 0 0.125rem 0.5rem 0.125rem #00000019;

--- a/build/web/scss/base.scss
+++ b/build/web/scss/base.scss
@@ -20,6 +20,7 @@ $gcds-color-grayscale-1000: #000000;
 $gcds-color-green-100: #e6f6ec;
 $gcds-color-green-500: #289f58; // Must contrast 3:1 with white
 $gcds-color-green-700: #03662a; // Must contrast 7:1 with white
+$gcds-color-green-800: #023b1a;
 $gcds-color-purple-700: #7532b8; // Must contrast 7:1 with white
 $gcds-color-orange-700: #be5a00; // Must contrast 7:1 with white
 $gcds-color-red-100: #fbddda;

--- a/build/web/scss/base/color.scss
+++ b/build/web/scss/base/color.scss
@@ -20,6 +20,7 @@ $gcds-color-grayscale-1000: #000000;
 $gcds-color-green-100: #e6f6ec;
 $gcds-color-green-500: #289f58; // Must contrast 3:1 with white
 $gcds-color-green-700: #03662a; // Must contrast 7:1 with white
+$gcds-color-green-800: #023b1a;
 $gcds-color-purple-700: #7532b8; // Must contrast 7:1 with white
 $gcds-color-orange-700: #be5a00; // Must contrast 7:1 with white
 $gcds-color-red-100: #fbddda;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -136,8 +136,10 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-$gcds-button-padding: 0.625rem 0.75rem;
+$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+$gcds-button-padding: 0.625rem 1rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
 $gcds-button-primary-hover-background: #2b4380;
@@ -153,10 +155,19 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd;
-$gcds-button-shared-disabled-text: #545961;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-$gcds-button-small-padding: 0.75rem;
+$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
+$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
+$gcds-button-shared-disabled-opacity: 50%;
+$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+$gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+$gcds-button-small-padding: 0.375rem 1rem;
+$gcds-button-start-default-background: #03662a;
+$gcds-button-start-default-text: #ffffff;
+$gcds-button-start-hover-background: #023b1a;
+$gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+$gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-start-padding: 0.75rem 2rem;
 $gcds-button-width: fit-content;
 $gcds-card-background-color: #ffffff;
 $gcds-card-box-shadow: 0 0.125rem 0.5rem 0.125rem #00000019;

--- a/build/web/scss/components/button.scss
+++ b/build/web/scss/components/button.scss
@@ -6,8 +6,10 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-$gcds-button-padding: 0.625rem 0.75rem;
+$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+$gcds-button-padding: 0.625rem 1rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
 $gcds-button-primary-hover-background: #2b4380;
@@ -23,8 +25,17 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd;
-$gcds-button-shared-disabled-text: #545961;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-$gcds-button-small-padding: 0.75rem;
+$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
+$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
+$gcds-button-shared-disabled-opacity: 50%;
+$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+$gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+$gcds-button-small-padding: 0.375rem 1rem;
+$gcds-button-start-default-background: #03662a;
+$gcds-button-start-default-text: #ffffff;
+$gcds-button-start-hover-background: #023b1a;
+$gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+$gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-start-padding: 0.75rem 2rem;
 $gcds-button-width: fit-content;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -20,6 +20,7 @@ $gcds-color-grayscale-1000: #000000;
 $gcds-color-green-100: #e6f6ec;
 $gcds-color-green-500: #289f58; // Must contrast 3:1 with white
 $gcds-color-green-700: #03662a; // Must contrast 7:1 with white
+$gcds-color-green-800: #023b1a;
 $gcds-color-purple-700: #7532b8; // Must contrast 7:1 with white
 $gcds-color-orange-700: #be5a00; // Must contrast 7:1 with white
 $gcds-color-red-100: #fbddda;
@@ -296,8 +297,10 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif;
-$gcds-button-padding: 0.625rem 0.75rem;
+$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
+$gcds-button-padding: 0.625rem 1rem;
 $gcds-button-primary-default-background: #26374a;
 $gcds-button-primary-default-text: #ffffff;
 $gcds-button-primary-hover-background: #2b4380;
@@ -313,10 +316,19 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd;
-$gcds-button-shared-disabled-text: #545961;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif;
-$gcds-button-small-padding: 0.75rem;
+$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
+$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
+$gcds-button-shared-disabled-opacity: 50%;
+$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
+$gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
+$gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
+$gcds-button-small-padding: 0.375rem 1rem;
+$gcds-button-start-default-background: #03662a;
+$gcds-button-start-default-text: #ffffff;
+$gcds-button-start-hover-background: #023b1a;
+$gcds-button-start-font-desktop: 600 1.375rem/145% 'Noto Sans', sans-serif;
+$gcds-button-start-font-mobile: 500 1.25rem/140% 'Noto Sans', sans-serif;
+$gcds-button-start-padding: 0.75rem 2rem;
 $gcds-button-width: fit-content;
 $gcds-card-background-color: #ffffff;
 $gcds-card-box-shadow: 0 0.125rem 0.5rem 0.125rem #00000019;

--- a/config/tailwind/v3.x.x/tailwind.config.js
+++ b/config/tailwind/v3.x.x/tailwind.config.js
@@ -69,6 +69,7 @@ module.exports = {
         100: green[100].value,
         500: green[500].value,
         700: green[700].value,
+        800: green[800].value,
       },
       orange: {
         700: orange[700].value,

--- a/config/tailwind/v4.x.x/css-config/src/input.css
+++ b/config/tailwind/v4.x.x/css-config/src/input.css
@@ -135,6 +135,7 @@
   --color-green-100: var(--gcds-color-green-100);
   --color-green-500: var(--gcds-color-green-500);
   --color-green-700: var(--gcds-color-green-700);
+  --color-green-800: var(--gcds-color-green-800);
 
   /* Colour: Orange */
   --color-orange-700: var(--gcds-color-orange-700);

--- a/config/tailwind/v4.x.x/js-config/tailwind.config.js
+++ b/config/tailwind/v4.x.x/js-config/tailwind.config.js
@@ -69,6 +69,7 @@ module.exports = {
         100: green[100].value,
         500: green[500].value,
         700: green[700].value,
+        800: green[800].value,
       },
       orange: {
         700: orange[700].value,

--- a/tokens/base/color/tokens.json
+++ b/tokens/base/color/tokens.json
@@ -87,6 +87,10 @@
         "value": "#03662A",
         "type": "color",
         "comment": "Must contrast 7:1 with white"
+      },
+      "800": {
+        "value": "#023b1a",
+        "type": "color"
       }
     },
     "purple": {

--- a/tokens/components/button/tokens.json
+++ b/tokens/components/button/tokens.json
@@ -29,16 +29,37 @@
       }
     },
     "font": {
-      "value": {
-        "fontFamily": "{fontFamilies.body}",
-        "fontWeight": "{fontWeights.medium}",
-        "lineHeight": "140%",
-        "fontSize": "{fontSizes.text}"
+      "-": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.medium}",
+          "lineHeight": "140%",
+          "fontSize": "{fontSizes.text}"
+        },
+        "type": "typography",
+        "comment": "To be removed in anouther PR"
       },
-      "type": "typography"
+      "desktop": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.medium}",
+          "lineHeight": "140%",
+          "fontSize": "{fontSizes.text}"
+        },
+        "type": "typography"
+      },
+      "mobile": {
+        "value": {
+          "fontFamily": "{fontFamilies.body}",
+          "fontWeight": "{fontWeights.medium}",
+          "lineHeight": "140%",
+          "fontSize": "{fontSizes.textMobile}"
+        },
+        "type": "typography"
+      }
     },
     "padding": {
-      "value": "{spacing.125.value} {spacing.150.value}",
+      "value": "{spacing.125.value} {spacing.200.value}",
       "type": "spacing"
     },
     "primary": {
@@ -127,26 +148,95 @@
       "disabled": {
         "background": {
           "value": "{disabled.background.value}",
-          "type": "color"
+          "type": "color",
+          "comment": "To be removed in anouther PR"
         },
         "text": {
           "value": "{disabled.text.value}",
-          "type": "color"
+          "type": "color",
+          "comment": "To be removed in anouther PR"
+        },
+        "opacity": {
+          "value": "50%",
+          "type": "other"
         }
       }
     },
     "small": {
       "font": {
-        "value": {
-          "fontFamily": "{fontFamilies.body}",
-          "fontWeight": "{fontWeights.regular}",
-          "lineHeight": "{lineHeights.text}",
-          "fontSize": "80%"
+        "-": {
+          "value": {
+            "fontFamily": "{fontFamilies.body}",
+            "fontWeight": "{fontWeights.regular}",
+            "lineHeight": "{lineHeights.text}",
+            "fontSize": "80%"
+          },
+          "type": "typography",
+          "comment": "To be removed in anouther PR"
         },
-        "type": "typography"
+        "desktop": {
+          "value": {
+            "fontFamily": "{fontFamilies.body}",
+            "fontWeight": "{fontWeights.regular}",
+            "lineHeight": "{lineHeights.textSmall}",
+            "fontSize": "{fontSizes.textSmall}"
+          },
+          "type": "typography"
+        },
+        "mobile": {
+          "value": {
+            "fontFamily": "{fontFamilies.body}",
+            "fontWeight": "{fontWeights.regular}",
+            "lineHeight": "{lineHeights.textSmallMobile}",
+            "fontSize": "{fontSizes.textSmallMobile}"
+          },
+          "type": "typography"
+        }
       },
       "padding": {
-        "value": "{spacing.150.value}",
+        "value": "{spacing.75.value} {spacing.200.value}",
+        "type": "spacing"
+      }
+    },
+    "start": {
+      "default": {
+        "background": {
+          "value": "{color.green.700.value}",
+          "type": "color"
+        },
+        "text": {
+          "value": "{text.light.value}",
+          "type": "color"
+        }
+      },
+      "hover": {
+        "background": {
+          "value": "{color.green.800.value}",
+          "type": "color"
+        }
+      },
+      "font": {
+        "desktop": {
+          "value": {
+            "fontFamily": "{fontFamilies.body}",
+            "fontWeight": "{fontWeights.semibold}",
+            "lineHeight": "{lineHeights.h6}",
+            "fontSize": "{fontSizes.h6}"
+          },
+          "type": "typography"
+        },
+        "mobile": {
+          "value": {
+            "fontFamily": "{fontFamilies.body}",
+            "fontWeight": "{fontWeights.medium}",
+            "lineHeight": "{lineHeights.h6Mobile}",
+            "fontSize": "{fontSizes.h6Mobile}"
+          },
+          "type": "typography"
+        }
+      },
+      "padding": {
+        "value": "{spacing.150.value} {spacing.400.value}",
         "type": "spacing"
       }
     },


### PR DESCRIPTION
# Summary | Résumé

For alignment with design.canada.ca, add component tokens for new button role start.

## Changes

- new button role tokens
- New disabled token to set opacity to `50%`
- Small padding updates for all buttons

**Note:** To be used with https://github.com/cds-snc/gcds-components/pull/775