### PR TITLE
remove: Remove old button tokens

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -1468,15 +1468,6 @@
         }
       },
       "font": {
-        "-": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "500",
-            "lineHeight": "140%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
-        },
         "desktop": {
           "value": {
             "fontFamily": "'Noto Sans', sans-serif",
@@ -1584,14 +1575,6 @@
           }
         },
         "disabled": {
-          "background": {
-            "value": "#D6D9DD",
-            "type": "color"
-          },
-          "text": {
-            "value": "#545961",
-            "type": "color"
-          },
           "opacity": {
             "value": "50%",
             "type": "other"
@@ -1600,15 +1583,6 @@
       },
       "small": {
         "font": {
-          "-": {
-            "value": {
-              "fontFamily": "'Noto Sans', sans-serif",
-              "fontWeight": "400",
-              "lineHeight": "160%",
-              "fontSize": "80%"
-            },
-            "type": "typography"
-          },
           "desktop": {
             "value": {
               "fontFamily": "'Noto Sans', sans-serif",

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -1468,15 +1468,6 @@
         }
       },
       "font": {
-        "-": {
-          "value": {
-            "fontFamily": "'Noto Sans', sans-serif",
-            "fontWeight": "500",
-            "lineHeight": "140%",
-            "fontSize": "1.25rem"
-          },
-          "type": "typography"
-        },
         "desktop": {
           "value": {
             "fontFamily": "'Noto Sans', sans-serif",
@@ -1584,14 +1575,6 @@
           }
         },
         "disabled": {
-          "background": {
-            "value": "#D6D9DD",
-            "type": "color"
-          },
-          "text": {
-            "value": "#545961",
-            "type": "color"
-          },
           "opacity": {
             "value": "50%",
             "type": "other"
@@ -1600,15 +1583,6 @@
       },
       "small": {
         "font": {
-          "-": {
-            "value": {
-              "fontFamily": "'Noto Sans', sans-serif",
-              "fontWeight": "400",
-              "lineHeight": "160%",
-              "fontSize": "80%"
-            },
-            "type": "typography"
-          },
           "desktop": {
             "value": {
               "fontFamily": "'Noto Sans', sans-serif",

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -138,7 +138,6 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
   --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
   --gcds-button-padding: 0.625rem 1rem;
@@ -157,10 +156,7 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
-  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
   --gcds-button-shared-disabled-opacity: 50%;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
   --gcds-button-small-padding: 0.375rem 1rem;

--- a/build/web/css/components/button.css
+++ b/build/web/css/components/button.css
@@ -8,7 +8,6 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
   --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
   --gcds-button-padding: 0.625rem 1rem;
@@ -27,10 +26,7 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
-  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
   --gcds-button-shared-disabled-opacity: 50%;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
   --gcds-button-small-padding: 0.375rem 1rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -299,7 +299,6 @@
   --gcds-button-danger-default-background: #a62a1e;
   --gcds-button-danger-default-text: #ffffff;
   --gcds-button-danger-hover-background: #822117;
-  --gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
   --gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
   --gcds-button-padding: 0.625rem 1rem;
@@ -318,10 +317,7 @@
   --gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
   --gcds-button-shared-focus-outline-width: 0.25rem;
   --gcds-button-shared-focus-text: #ffffff;
-  --gcds-button-shared-disabled-background: #d6d9dd; /* To be removed in anouther PR */
-  --gcds-button-shared-disabled-text: #545961; /* To be removed in anouther PR */
   --gcds-button-shared-disabled-opacity: 50%;
-  --gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; /* To be removed in anouther PR */
   --gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
   --gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
   --gcds-button-small-padding: 0.375rem 1rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -136,7 +136,6 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
 $gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
 $gcds-button-padding: 0.625rem 1rem;
@@ -155,10 +154,7 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
-$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
 $gcds-button-shared-disabled-opacity: 50%;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
 $gcds-button-small-padding: 0.375rem 1rem;

--- a/build/web/scss/components/button.scss
+++ b/build/web/scss/components/button.scss
@@ -6,7 +6,6 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
 $gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
 $gcds-button-padding: 0.625rem 1rem;
@@ -25,10 +24,7 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
-$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
 $gcds-button-shared-disabled-opacity: 50%;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
 $gcds-button-small-padding: 0.375rem 1rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -297,7 +297,6 @@ $gcds-button-border-width: 0.125rem;
 $gcds-button-danger-default-background: #a62a1e;
 $gcds-button-danger-default-text: #ffffff;
 $gcds-button-danger-hover-background: #822117;
-$gcds-button-font: 500 1.25rem/140% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-font-desktop: 500 1.25rem/140% 'Noto Sans', sans-serif;
 $gcds-button-font-mobile: 500 1.125rem/140% 'Noto Sans', sans-serif;
 $gcds-button-padding: 0.625rem 1rem;
@@ -316,10 +315,7 @@ $gcds-button-shared-focus-background: #0535d2;
 $gcds-button-shared-focus-box-shadow: 0 0 0 0.125rem #ffffff;
 $gcds-button-shared-focus-outline-width: 0.25rem;
 $gcds-button-shared-focus-text: #ffffff;
-$gcds-button-shared-disabled-background: #d6d9dd; // To be removed in anouther PR
-$gcds-button-shared-disabled-text: #545961; // To be removed in anouther PR
 $gcds-button-shared-disabled-opacity: 50%;
-$gcds-button-small-font: 400 80%/160% 'Noto Sans', sans-serif; // To be removed in anouther PR
 $gcds-button-small-font-desktop: 400 1.125rem/155% 'Noto Sans', sans-serif;
 $gcds-button-small-font-mobile: 400 1rem/150% 'Noto Sans', sans-serif;
 $gcds-button-small-padding: 0.375rem 1rem;

--- a/tokens/components/button/tokens.json
+++ b/tokens/components/button/tokens.json
@@ -29,16 +29,6 @@
       }
     },
     "font": {
-      "-": {
-        "value": {
-          "fontFamily": "{fontFamilies.body}",
-          "fontWeight": "{fontWeights.medium}",
-          "lineHeight": "140%",
-          "fontSize": "{fontSizes.text}"
-        },
-        "type": "typography",
-        "comment": "To be removed in anouther PR"
-      },
       "desktop": {
         "value": {
           "fontFamily": "{fontFamilies.body}",
@@ -146,16 +136,6 @@
         }
       },
       "disabled": {
-        "background": {
-          "value": "{disabled.background.value}",
-          "type": "color",
-          "comment": "To be removed in anouther PR"
-        },
-        "text": {
-          "value": "{disabled.text.value}",
-          "type": "color",
-          "comment": "To be removed in anouther PR"
-        },
         "opacity": {
           "value": "50%",
           "type": "other"
@@ -164,16 +144,6 @@
     },
     "small": {
       "font": {
-        "-": {
-          "value": {
-            "fontFamily": "{fontFamilies.body}",
-            "fontWeight": "{fontWeights.regular}",
-            "lineHeight": "{lineHeights.text}",
-            "fontSize": "80%"
-          },
-          "type": "typography",
-          "comment": "To be removed in anouther PR"
-        },
         "desktop": {
           "value": {
             "fontFamily": "{fontFamilies.body}",


### PR DESCRIPTION
# Summary | Résumé

After the button component work to align all mandatory elements, some of the button component tokens are no longer being used and can be removed.

## Tokens being removed

- `--gcds-button-font`
- `--gcds-button-small-font`
- `--gcds-button-shared-disabled-background`
- `--gcds-button-shared-disabled-text`

