### PR TITLE
feat: add default GCDS typography styles to Tailwind configs

### DIFF
--- a/config/tailwind/v3.x.x/src/input.css
+++ b/config/tailwind/v3.x.x/src/input.css
@@ -1,4 +1,127 @@
+/* Import GCDS tokens */
+@import "@cdssnc/gcds-tokens/build/web/css/tokens.css";
+
 /* Import Tailwind CSS */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ----- Default GCDS typography styles ----- */
+@layer base {
+  body {
+    font: var(--gcds-font-text);
+  }
+
+  @media only screen and (width < 48em) {
+    body {
+      font: var(--gcds-font-text-mobile);
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-block-start: var(--gcds-heading-spacing-600);
+  }
+
+  h1 {
+    max-width: var(--gcds-heading-character-limit-h1);
+    font: var(--gcds-heading-h1-desktop);
+    margin-block-start: var(--gcds-heading-spacing-0);
+  }
+
+  h1:after {
+    display: block;
+    content: "";
+    width: var(--gcds-heading-h1-border-width);
+    margin-block-start: var(--gcds-heading-h1-border-margin);
+    height: var(--gcds-heading-h1-border-height);
+    background-color: var(--gcds-heading-h1-border-background);
+  }
+
+  @media only screen and (width < 48em) {
+    h1 {
+      font: var(--gcds-heading-h1-mobile);
+    }
+  }
+
+  h2 {
+    max-width: var(--gcds-heading-character-limit-h2);
+    font: var(--gcds-heading-h2-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h2 {
+      font: var(--gcds-heading-h2-mobile);
+    }
+  }
+
+  h3 {
+    max-width: var(--gcds-heading-character-limit-h3);
+    font: var(--gcds-heading-h3-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h3 {
+      font: var(--gcds-heading-h3-mobile);
+    }
+  }
+
+  h4 {
+    max-width: var(--gcds-heading-character-limit-h4);
+    font: var(--gcds-heading-h4-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h4 {
+      font: var(--gcds-heading-h4-mobile);
+    }
+  }
+
+  h5 {
+    max-width: var(--gcds-heading-character-limit-h5);
+    font: var(--gcds-heading-h5-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h5 {
+      font: var(--gcds-heading-h5-mobile);
+    }
+  }
+
+  h6 {
+    max-width: var(--gcds-heading-character-limit-h6);
+    font: var(--gcds-heading-h6-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h6 {
+      font: var(--gcds-heading-h6-mobile);
+    }
+  }
+
+  p {
+    max-width: var(--gcds-text-character-limit);
+    font: var(--gcds-font-text);
+    margin-block-start: var(--gcds-heading-spacing-0);
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  @media only screen and (width < 48em) {
+    p {
+      font: var(--gcds-font-text-mobile);
+    }
+  }
+}

--- a/config/tailwind/v4.x.x/css-config/src/input.css
+++ b/config/tailwind/v4.x.x/css-config/src/input.css
@@ -14,12 +14,130 @@
     border-color: var(--gcds-border-default, currentColor);
   }
 
+  /* ----- Default GCDS typography styles ----- */
+  body {
+    font: var(--gcds-font-text);
+  }
+
+  @media only screen and (width < 48em) {
+    body {
+      font: var(--gcds-font-text-mobile);
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-block-start: var(--gcds-heading-spacing-600);
+  }
+
+  h1 {
+    max-width: var(--gcds-heading-character-limit-h1);
+    font: var(--gcds-heading-h1-desktop);
+    margin-block-start: var(--gcds-heading-spacing-0);
+  }
+
+  h1:after {
+    display: block;
+    content: "";
+    width: var(--gcds-heading-h1-border-width);
+    margin-block-start: var(--gcds-heading-h1-border-margin);
+    height: var(--gcds-heading-h1-border-height);
+    background-color: var(--gcds-heading-h1-border-background);
+  }
+
+  @media only screen and (width < 48em) {
+    h1 {
+      font: var(--gcds-heading-h1-mobile);
+    }
+  }
+
+  h2 {
+    max-width: var(--gcds-heading-character-limit-h2);
+    font: var(--gcds-heading-h2-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h2 {
+      font: var(--gcds-heading-h2-mobile);
+    }
+  }
+
+  h3 {
+    max-width: var(--gcds-heading-character-limit-h3);
+    font: var(--gcds-heading-h3-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h3 {
+      font: var(--gcds-heading-h3-mobile);
+    }
+  }
+
+  h4 {
+    max-width: var(--gcds-heading-character-limit-h4);
+    font: var(--gcds-heading-h4-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h4 {
+      font: var(--gcds-heading-h4-mobile);
+    }
+  }
+
+  h5 {
+    max-width: var(--gcds-heading-character-limit-h5);
+    font: var(--gcds-heading-h5-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h5 {
+      font: var(--gcds-heading-h5-mobile);
+    }
+  }
+
+  h6 {
+    max-width: var(--gcds-heading-character-limit-h6);
+    font: var(--gcds-heading-h6-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h6 {
+      font: var(--gcds-heading-h6-mobile);
+    }
+  }
+
+  p {
+    max-width: var(--gcds-text-character-limit);
+    font: var(--gcds-font-text);
+    margin-block-start: var(--gcds-heading-spacing-0);
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  @media only screen and (width < 48em) {
+    p {
+      font: var(--gcds-font-text-mobile);
+    }
+  }
+
   /* Default font size */
   .text {
     font-size: var(--gcds-font-sizes-text);
   }
 
-  /* ----- Font ----- */
+  /* ----- Custom font classes ----- */
   /* Custom font classes defining font weight, font size/line height and font family in one. */
   .font-h1 {
     font: var(--gcds-heading-h1-desktop);
@@ -85,7 +203,7 @@
     }
   }
 
-  /* ----- Link colours ----- */
+  /* ----- Custom link colours ----- */
 
   /* Default link colour for links on a white background. */
   .link-default {

--- a/config/tailwind/v4.x.x/js-config/src/input.css
+++ b/config/tailwind/v4.x.x/js-config/src/input.css
@@ -5,7 +5,7 @@
 @config "../tailwind.config.js";
 
 /* Import GCDS tokens */
-@import "../node_modules/@cdssnc/gcds-tokens/build/web/css/tokens.css";
+@import "@cdssnc/gcds-tokens/build/web/css/tokens.css";
 
 @layer base {
   *,
@@ -18,5 +18,123 @@
 
   .text {
     font-size: var(--gcds-font-sizes-text);
+  }
+
+  /* ----- Default GCDS typography styles ----- */
+  body {
+    font: var(--gcds-font-text);
+  }
+
+  @media only screen and (width < 48em) {
+    body {
+      font: var(--gcds-font-text-mobile);
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin-block-start: var(--gcds-heading-spacing-600);
+  }
+
+  h1 {
+    max-width: var(--gcds-heading-character-limit-h1);
+    font: var(--gcds-heading-h1-desktop);
+    margin-block-start: var(--gcds-heading-spacing-0);
+  }
+
+  h1:after {
+    display: block;
+    content: "";
+    width: var(--gcds-heading-h1-border-width);
+    margin-block-start: var(--gcds-heading-h1-border-margin);
+    height: var(--gcds-heading-h1-border-height);
+    background-color: var(--gcds-heading-h1-border-background);
+  }
+
+  @media only screen and (width < 48em) {
+    h1 {
+      font: var(--gcds-heading-h1-mobile);
+    }
+  }
+
+  h2 {
+    max-width: var(--gcds-heading-character-limit-h2);
+    font: var(--gcds-heading-h2-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h2 {
+      font: var(--gcds-heading-h2-mobile);
+    }
+  }
+
+  h3 {
+    max-width: var(--gcds-heading-character-limit-h3);
+    font: var(--gcds-heading-h3-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h3 {
+      font: var(--gcds-heading-h3-mobile);
+    }
+  }
+
+  h4 {
+    max-width: var(--gcds-heading-character-limit-h4);
+    font: var(--gcds-heading-h4-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h4 {
+      font: var(--gcds-heading-h4-mobile);
+    }
+  }
+
+  h5 {
+    max-width: var(--gcds-heading-character-limit-h5);
+    font: var(--gcds-heading-h5-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h5 {
+      font: var(--gcds-heading-h5-mobile);
+    }
+  }
+
+  h6 {
+    max-width: var(--gcds-heading-character-limit-h6);
+    font: var(--gcds-heading-h6-desktop);
+  }
+
+  @media only screen and (width < 48em) {
+    h6 {
+      font: var(--gcds-heading-h6-mobile);
+    }
+  }
+
+  p {
+    max-width: var(--gcds-text-character-limit);
+    font: var(--gcds-font-text);
+    margin-block-start: var(--gcds-heading-spacing-0);
+    margin-block-end: var(--gcds-heading-spacing-300);
+  }
+
+  @media only screen and (width < 48em) {
+    p {
+      font: var(--gcds-font-text-mobile);
+    }
   }
 }


### PR DESCRIPTION
# Summary | Résumé

Based on user feedback, we are incorporating the default GCDS typography styles into our new Tailwind config files for all headings and paragraphs. This update allows users to seamlessly apply the same GCDS typography styles to their Tailwind projects as those used in the GCDS components, without the need to add additional CSS classes.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1478) for this new feature.
