### PR TITLE
feat: add custom focus class for interactive elements to Tailwind configs

### DIFF
--- a/config/tailwind/v3.x.x/tailwind.config.js
+++ b/config/tailwind/v3.x.x/tailwind.config.js
@@ -221,16 +221,29 @@ module.exports = {
         full: container.full.value,
       },
       // Matches GCDS container sizes
-      maxWidth: (theme) => ({
-        ...theme('width'),
-      }),
+      maxWidth: theme => theme('width'),
       // Matches GCDS container sizes
-      minWidth: (theme) => ({
-        ...theme('width'),
-      }),
+      minWidth: theme => theme('width'),
     },
   },
   plugins: [
+    // Custom focus class
+    function ({ addUtilities }) {
+      const customFocusStyle = {
+        '.focus:focus': {
+          backgroundColor: link.focus.background.value,
+          color: link.focus.text.value,
+          borderRadius: link.focus.border.radius.value,
+          boxShadow: link.focus["box-shadow"].value,
+          outline: `${link.focus.outline.width.value} solid ${link.focus.background.value}`,
+          outlineOffset: link.focus["outline-offset"].value,
+          textDecoration: 'none',
+        },
+      };
+
+      addUtilities(customFocusStyle, ['focus']);
+    },
+
     // Custom link color classes.
     function ({ addUtilities, theme }) {
       const linkColors = theme('linkColor');

--- a/config/tailwind/v4.x.x/css-config/src/input.css
+++ b/config/tailwind/v4.x.x/css-config/src/input.css
@@ -203,6 +203,17 @@
     }
   }
 
+  /* ----- Custom focus class ----- */
+  .focus:focus {
+    background-color: var(--gcds-link-focus-background);
+    color: var(--gcds-link-focus-text) !important;
+    border-radius: var(--gcds-link-focus-border-radius);
+    box-shadow: var(--gcds-link-focus-box-shadow);
+    outline: var(--gcds-link-focus-outline-width) solid var(--gcds-link-focus-background);
+    outline-offset: var(--gcds-link-focus-outline-offset);
+    text-decoration: none;
+  }
+
   /* ----- Custom link colours ----- */
 
   /* Default link colour for links on a white background. */

--- a/config/tailwind/v4.x.x/js-config/tailwind.config.js
+++ b/config/tailwind/v4.x.x/js-config/tailwind.config.js
@@ -213,16 +213,29 @@ module.exports = {
         full: container.full.value,
       },
       // Matches GCDS container sizes
-      maxWidth: (theme) => ({
-        ...theme('width'),
-      }),
+      maxWidth: theme => theme('width'),
       // Matches GCDS container sizes
-      minWidth: (theme) => ({
-        ...theme('width'),
-      }),
+      minWidth: theme => theme('width'),
     },
   },
   plugins: [
+    // Custom focus class
+    function ({ addUtilities }) {
+      const customFocusStyle = {
+        '.focus:focus': {
+          backgroundColor: link.focus.background.value,
+          color: link.focus.text.value,
+          borderRadius: link.focus.border.radius.value,
+          boxShadow: link.focus["box-shadow"].value,
+          outline: `${link.focus.outline.width.value} solid ${link.focus.background.value}`,
+          outlineOffset: link.focus["outline-offset"].value,
+          textDecoration: 'none',
+        },
+      };
+
+      addUtilities(customFocusStyle, ['focus']);
+    },
+
     // Custom link color classes.
     function ({ addUtilities, theme }) {
       const linkColors = theme('linkColor');


### PR DESCRIPTION
# Summary | Résumé

We are incorporating the default GCDS focus style as custom `focus` class into our new Tailwind config files. This update allows users to seamlessly apply the same GCDS focus styles to their Tailwind projects as those used in the GCDS components.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1487) for this new feature.
