### PR TITLE
feat: add custom full-width-bg class to tailwind configs

### DIFF
--- a/config/tailwind/v3.x.x/src/input.css
+++ b/config/tailwind/v3.x.x/src/input.css
@@ -6,6 +6,13 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Prevent mobile overflow */
+body,
+html {
+  overflow-x: hidden;
+  width: 100%;
+}
+
 /* ----- Default GCDS typography styles ----- */
 @layer base {
   body {

--- a/config/tailwind/v3.x.x/tailwind.config.js
+++ b/config/tailwind/v3.x.x/tailwind.config.js
@@ -227,6 +227,34 @@ module.exports = {
     },
   },
   plugins: [
+    // Custom class for full width background colour
+    function ({ addUtilities }) {
+      const bgFullWidthStyle = {
+        '.bg-full-width': {
+          position: 'relative',
+          width: 'calc(100% + var(--gcds-spacing-225))',
+          marginInline: 'calc(-1 * var(--gcds-spacing-100))',
+          paddingInline: 'var(--gcds-spacing-100)',
+        },
+        '.bg-full-width:before, .bg-full-width:after': {
+          position: 'absolute',
+          top: '0',
+          width: '100vw',
+          height: '100%',
+          content: "''",
+          backgroundColor: 'inherit',
+        },
+        '.bg-full-width:before': {
+          left: 'calc(-100vw + 1px)',
+        },
+        '.bg-full-width:after': {
+          right: 'calc(-100vw + 1px)',
+        },
+      };
+
+      addUtilities(bgFullWidthStyle, ['responsive', 'hover', 'focus']);
+    },
+
     // Custom focus class
     function ({ addUtilities }) {
       const customFocusStyle = {

--- a/config/tailwind/v4.x.x/css-config/src/input.css
+++ b/config/tailwind/v4.x.x/css-config/src/input.css
@@ -14,6 +14,13 @@
     border-color: var(--gcds-border-default, currentColor);
   }
 
+  /* Prevent mobile overflow */
+  body,
+  html {
+    overflow-x: hidden;
+    width: 100%;
+  }
+
   /* ----- Default GCDS typography styles ----- */
   body {
     font: var(--gcds-font-text);
@@ -135,6 +142,32 @@
   /* Default font size */
   .text {
     font-size: var(--gcds-font-sizes-text);
+  }
+
+  /* ----- Custom class for full width background colour ----- */
+  .bg-full-width {
+    position: relative;
+    width: calc(100% + var(--gcds-spacing-225));
+    margin-inline: calc(-1 * var(--gcds-spacing-100));
+    padding-inline: var(--gcds-spacing-100);
+
+    &:before,
+    &:after {
+      position: absolute;
+      top: 0;
+      width: 100vw;
+      height: 100%;
+      content: '';
+      background-color: inherit;
+    }
+
+    &:before {
+      left: calc(-100vw + 1px);
+    }
+
+    &:after {
+      right: calc(-100vw + 1px);
+    }
   }
 
   /* ----- Custom font classes ----- */

--- a/config/tailwind/v4.x.x/js-config/src/input.css
+++ b/config/tailwind/v4.x.x/js-config/src/input.css
@@ -16,6 +16,13 @@
     border-color: var(--gcds-border-default);
   }
 
+  /* Prevent mobile overflow */
+  body,
+  html {
+    overflow-x: hidden;
+    width: 100%;
+  }
+
   .text {
     font-size: var(--gcds-font-sizes-text);
   }

--- a/config/tailwind/v4.x.x/js-config/tailwind.config.js
+++ b/config/tailwind/v4.x.x/js-config/tailwind.config.js
@@ -219,6 +219,34 @@ module.exports = {
     },
   },
   plugins: [
+    // Custom class for full width background colour
+    function ({ addUtilities }) {
+      const bgFullWidthStyle = {
+        '.bg-full-width': {
+          position: 'relative',
+          width: 'calc(100% + var(--gcds-spacing-225))',
+          marginInline: 'calc(-1 * var(--gcds-spacing-100))',
+          paddingInline: 'var(--gcds-spacing-100)',
+        },
+        '.bg-full-width:before, .bg-full-width:after': {
+          position: 'absolute',
+          top: '0',
+          width: '100vw',
+          height: '100%',
+          content: "''",
+          backgroundColor: 'inherit',
+        },
+        '.bg-full-width:before': {
+          left: 'calc(-100vw + 1px)',
+        },
+        '.bg-full-width:after': {
+          right: 'calc(-100vw + 1px)',
+        },
+      };
+
+      addUtilities(bgFullWidthStyle, ['responsive', 'hover', 'focus']);
+    },
+
     // Custom focus class
     function ({ addUtilities }) {
       const customFocusStyle = {


### PR DESCRIPTION
# Summary | Résumé

We are incorporating a new custom `bg-full-width` class into our new Tailwind config files. This update allows users to apply a class that allows an element to stretch beyond its container’s edges, creating a background effect that extends across the entire screen.

Zenhub ticket
[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1486) for this new feature.