### PR TITLE
fix: mobile menu padding for Safari mobile

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3505,7 +3505,7 @@
           }
         },
         "padding": {
-          "value": "0.5rem 0.875rem 1.5rem 0.875rem",
+          "value": "0.5rem 0.875rem 4.75rem 0.875rem",
           "type": "spacing"
         },
         "trigger": {

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -3505,7 +3505,7 @@
           }
         },
         "padding": {
-          "value": "0.5rem 0.875rem 1.5rem 0.875rem",
+          "value": "0.5rem 0.875rem 4.75rem 0.875rem",
           "type": "spacing"
         },
         "trigger": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -500,7 +500,7 @@
   --gcds-lang-toggle-padding: 0.375rem 0.625rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
   --gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
   --gcds-nav-group-mobile-trigger-border-width: 0.125rem;
   --gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/build/web/css/components/nav-group.css
+++ b/build/web/css/components/nav-group.css
@@ -5,7 +5,7 @@
 :root {
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
   --gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
   --gcds-nav-group-mobile-trigger-border-width: 0.125rem;
   --gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -661,7 +661,7 @@
   --gcds-lang-toggle-padding: 0.375rem 0.625rem;
   --gcds-nav-group-mobile-background: #ffffff;
   --gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+  --gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
   --gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
   --gcds-nav-group-mobile-trigger-border-width: 0.125rem;
   --gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -498,7 +498,7 @@ $gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Man
 $gcds-lang-toggle-padding: 0.375rem 0.625rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
 $gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
 $gcds-nav-group-mobile-trigger-border-width: 0.125rem;
 $gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/build/web/scss/components/nav-group.scss
+++ b/build/web/scss/components/nav-group.scss
@@ -3,7 +3,7 @@
 
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
 $gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
 $gcds-nav-group-mobile-trigger-border-width: 0.125rem;
 $gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -659,7 +659,7 @@ $gcds-lang-toggle-font-mobile: 700 1.125rem/155% 'Noto Sans', sans-serif; // Man
 $gcds-lang-toggle-padding: 0.375rem 0.625rem;
 $gcds-nav-group-mobile-background: #ffffff;
 $gcds-nav-group-mobile-list-margin: 0.875rem 0 0;
-$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 1.5rem 0.875rem;
+$gcds-nav-group-mobile-padding: 0.5rem 0.875rem 4.75rem 0.875rem;
 $gcds-nav-group-mobile-trigger-border-radius: 0.375rem;
 $gcds-nav-group-mobile-trigger-border-width: 0.125rem;
 $gcds-nav-group-mobile-trigger-margin: 0.5rem;

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -12,7 +12,7 @@
         }
       },
       "padding": {
-        "value": "{spacing.100.value} {spacing.175.value} {spacing.300.value} {spacing.175.value}",
+        "value": "{spacing.100.value} {spacing.175.value} {spacing.950.value} {spacing.175.value}",
         "type": "spacing"
       },
       "trigger": {


### PR DESCRIPTION
# Summary | Résumé

Issue: https://github.com/cds-snc/gcds-components/issues/770

When using mobile Safari browser to browse a site/app with a large amount of menu items in the top-nav/side-nav. The last item in the menu list can be covered by the URL bar. To fix this the padding-bottom for the mobile menu has been increased to `--gcds-spacing-950` in the `--gcds-nav-group-mobile-padding` component token.

## How to test

1. With original padding values, create a page with a `gcds-side-nav` with many nav links.
2. View the page on a mobile Safari browser.
3. Notice the last nav link will be hidden and not accessible to click.
4. Update `--gcds-nav-group-mobile-padding` to the new value.
5. View the page on a mobile Safari browser.
6. Notice the last nav link will now be above the URL bar.
