### PR TITLE
feat: limit colours to gcds colours for Tailwind CSS config version 4

### DIFF
--- a/config/tailwind/v4.x.x/css-config/src/input.css
+++ b/config/tailwind/v4.x.x/css-config/src/input.css
@@ -273,6 +273,9 @@
 @theme {
   /* ----- Colours ----- */
 
+  /* Limit Tailwind colours to GCDS colours */
+  --color-*: initial;
+
   /* Colour: Blue */
   --color-blue-100: var(--gcds-color-blue-100);
   --color-blue-500: var(--gcds-color-blue-500);


### PR DESCRIPTION
# Summary | Résumé

Updating the Tailwind config for version 4 (CSS) to be limited to GC Design System colours only. The Tailwind config for version 4 (JS) and version 3 are already set to only use GC Design System colours.

## Zenhub ticket

[Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1485) for this change.
