### PR TITLE
remove: remove old nav-group token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3653,10 +3653,6 @@
               }
             }
           },
-          "margin-inline-start": {
-            "value": "0.125rem",
-            "type": "spacing"
-          },
           "decoration": {
             "thickness": {
               "value": "0.0625rem",

--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -4649,10 +4649,6 @@
       }
     },
     "top-nav": {
-      "background": {
-        "value": "#F1F2F3",
-        "type": "color"
-      },
       "border": {
         "color": {
           "value": "#D6D9DD",

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -3653,10 +3653,6 @@
               }
             }
           },
-          "margin-inline-start": {
-            "value": "0.125rem",
-            "type": "spacing"
-          },
           "decoration": {
             "thickness": {
               "value": "0.0625rem",

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -4649,10 +4649,6 @@
       }
     },
     "top-nav": {
-      "background": {
-        "value": "#F1F2F3",
-        "type": "color"
-      },
       "border": {
         "color": {
           "value": "#D6D9DD",

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -702,7 +702,6 @@
   --gcds-textarea-min-height: 3rem;
   --gcds-textarea-outline-width: 0.25rem;
   --gcds-textarea-padding: 0.5rem;
-  --gcds-top-nav-background: #f1f2f3; /* To be removed in another PR */
   --gcds-top-nav-border-color: #d6d9dd;
   --gcds-top-nav-border-width: 0.0625rem;
   --gcds-top-nav-max-width: 71.25rem;

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -528,7 +528,6 @@
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-  --gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; /* To be removed in another PR */
   --gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/build/web/css/components/nav-group.css
+++ b/build/web/css/components/nav-group.css
@@ -25,7 +25,6 @@
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-  --gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; /* To be removed in another PR */
   --gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/build/web/css/components/top-nav.css
+++ b/build/web/css/components/top-nav.css
@@ -3,7 +3,6 @@
  */
 
 :root {
-  --gcds-top-nav-background: #f1f2f3; /* To be removed in another PR */
   --gcds-top-nav-border-color: #d6d9dd;
   --gcds-top-nav-border-width: 0.0625rem;
   --gcds-top-nav-max-width: 71.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -864,7 +864,6 @@
   --gcds-textarea-min-height: 3rem;
   --gcds-textarea-outline-width: 0.25rem;
   --gcds-textarea-padding: 0.5rem;
-  --gcds-top-nav-background: #f1f2f3; /* To be removed in another PR */
   --gcds-top-nav-border-color: #d6d9dd;
   --gcds-top-nav-border-width: 0.0625rem;
   --gcds-top-nav-max-width: 71.25rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -690,7 +690,6 @@
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-  --gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; /* To be removed in another PR */
   --gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -700,7 +700,6 @@ $gcds-textarea-margin: 0 0 1.5rem;
 $gcds-textarea-min-height: 3rem;
 $gcds-textarea-outline-width: 0.25rem;
 $gcds-textarea-padding: 0.5rem;
-$gcds-top-nav-background: #f1f2f3; // To be removed in another PR
 $gcds-top-nav-border-color: #d6d9dd;
 $gcds-top-nav-border-width: 0.0625rem;
 $gcds-top-nav-max-width: 71.25rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -526,7 +526,6 @@ $gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-$gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; // To be removed in another PR
 $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/build/web/scss/components/nav-group.scss
+++ b/build/web/scss/components/nav-group.scss
@@ -23,7 +23,6 @@ $gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-$gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; // To be removed in another PR
 $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/build/web/scss/components/top-nav.scss
+++ b/build/web/scss/components/top-nav.scss
@@ -1,7 +1,6 @@
 
 // Do not edit directly, this file was auto-generated.
 
-$gcds-top-nav-background: #f1f2f3; // To be removed in another PR
 $gcds-top-nav-border-color: #d6d9dd;
 $gcds-top-nav-border-width: 0.0625rem;
 $gcds-top-nav-max-width: 71.25rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -862,7 +862,6 @@ $gcds-textarea-margin: 0 0 1.5rem;
 $gcds-textarea-min-height: 3rem;
 $gcds-textarea-outline-width: 0.25rem;
 $gcds-textarea-padding: 0.5rem;
-$gcds-top-nav-background: #f1f2f3; // To be removed in another PR
 $gcds-top-nav-border-color: #d6d9dd;
 $gcds-top-nav-border-width: 0.0625rem;
 $gcds-top-nav-max-width: 71.25rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -688,7 +688,6 @@ $gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;
-$gcds-nav-group-top-nav-trigger-margin-inline-start: 0.125rem; // To be removed in another PR
 $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -126,11 +126,6 @@
             }
           }
         },
-        "margin-inline-start": {
-          "value": "{spacing.25.value}",
-          "type": "spacing",
-          "comment": "To be removed in another PR"
-        },
         "decoration": {
           "thickness": {
             "value": "{border.width.sm.value}",

--- a/tokens/components/top-nav/tokens.json
+++ b/tokens/components/top-nav/tokens.json
@@ -1,10 +1,5 @@
 {
   "top-nav": {
-    "background": {
-      "value": "{bg.light.value}",
-      "type": "color",
-      "comment": "To be removed in another PR"
-    },
     "border": {
       "color": {
         "value": "{color.grayscale.100.value}",


### PR DESCRIPTION
# Summary | Résumé

As part of the new design for the top-nav component, we no longer need the some tokens for the top-nav and nav-group.

## Tokens being removed

The following top-nav and nav-group tokens will be removed because they will no longer be used in the new top-nav design:

- --gcds-nav-group-top-nav-trigger-margin-inline-start
- --gcds-top-nav-background

## Zenhub ticket

This is the [Zenhub ticket](https://app.zenhub.com/workspaces/gc-design-system-6100624a19f4cf000e46e458/issues/gh/cds-snc/design-gc-conception/1352) for the changes.

## Top-nav token change

The token changes for the top-nav design update can be found in [PR #440](https://github.com/cds-snc/gcds-tokens/pull/440).
