### PR TITLE
fix: adjust nav-group padding to align with nav links

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3678,7 +3678,7 @@
             }
           },
           "padding": {
-            "value": "1rem",
+            "value": "1.125rem 1rem",
             "type": "spacing"
           }
         }

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -3678,7 +3678,7 @@
             }
           },
           "padding": {
-            "value": "1rem",
+            "value": "1.125rem 1rem",
             "type": "spacing"
           }
         }

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -532,7 +532,7 @@
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-  --gcds-nav-group-top-nav-trigger-padding: 1rem;
+  --gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
   --gcds-nav-group-trigger-focus-background: #0535d2;
   --gcds-nav-group-trigger-focus-text: #ffffff;
   --gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/build/web/css/components/nav-group.css
+++ b/build/web/css/components/nav-group.css
@@ -29,7 +29,7 @@
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-  --gcds-nav-group-top-nav-trigger-padding: 1rem;
+  --gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
   --gcds-nav-group-trigger-focus-background: #0535d2;
   --gcds-nav-group-trigger-focus-text: #ffffff;
   --gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -694,7 +694,7 @@
   --gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
   --gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-  --gcds-nav-group-top-nav-trigger-padding: 1rem;
+  --gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
   --gcds-nav-group-trigger-focus-background: #0535d2;
   --gcds-nav-group-trigger-focus-text: #ffffff;
   --gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -530,7 +530,7 @@ $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-$gcds-nav-group-top-nav-trigger-padding: 1rem;
+$gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
 $gcds-nav-group-trigger-focus-background: #0535d2;
 $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/build/web/scss/components/nav-group.scss
+++ b/build/web/scss/components/nav-group.scss
@@ -27,7 +27,7 @@ $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-$gcds-nav-group-top-nav-trigger-padding: 1rem;
+$gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
 $gcds-nav-group-trigger-focus-background: #0535d2;
 $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -692,7 +692,7 @@ $gcds-nav-group-top-nav-trigger-decoration-thickness: 0.0625rem;
 $gcds-nav-group-top-nav-trigger-underline-offset: 0.25rem;
 $gcds-nav-group-top-nav-trigger-expanded-background-color: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-icon-margin: 0.5rem;
-$gcds-nav-group-top-nav-trigger-padding: 1rem;
+$gcds-nav-group-top-nav-trigger-padding: 1.125rem 1rem;
 $gcds-nav-group-trigger-focus-background: #0535d2;
 $gcds-nav-group-trigger-focus-text: #ffffff;
 $gcds-nav-group-trigger-focus-border-radius: 0.125rem;

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -151,7 +151,7 @@
           }
         },
         "padding": {
-          "value": "{spacing.200.value}",
+          "value": "{spacing.225.value} {spacing.200.value}",
           "type": "spacing"
         }
       }


### PR DESCRIPTION
# Summary | Résumé

Adjust padding for the nav-group component to align properly with the nav-links in the top-nav.

## Bug fixes

Fixes [this issue](https://github.com/cds-snc/gcds-components/issues/824).