### PR TITLE
remove: old nav-group top-nav trigger token

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3635,12 +3635,6 @@
           "type": "typography"
         },
         "trigger": {
-          "border": {
-            "width": {
-              "value": "0.25rem",
-              "type": "borderWidth"
-            }
-          },
           "hover": {
             "background": {
               "value": "#D6D9DD",

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -3635,12 +3635,6 @@
           "type": "typography"
         },
         "trigger": {
-          "border": {
-            "width": {
-              "value": "0.25rem",
-              "type": "borderWidth"
-            }
-          },
           "hover": {
             "background": {
               "value": "#D6D9DD",

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -525,7 +525,6 @@
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/build/web/css/components/nav-group.css
+++ b/build/web/css/components/nav-group.css
@@ -21,7 +21,6 @@
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -687,7 +687,6 @@
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;
   --gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-  --gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
   --gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
   --gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
   --gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -523,7 +523,6 @@ $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;
 $gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-$gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/build/web/scss/components/nav-group.scss
+++ b/build/web/scss/components/nav-group.scss
@@ -19,7 +19,6 @@ $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;
 $gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-$gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -685,7 +685,6 @@ $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;
 $gcds-nav-group-top-nav-font: 500 1rem/150% 'Noto Sans', sans-serif;
-$gcds-nav-group-top-nav-trigger-border-width: 0.25rem;
 $gcds-nav-group-top-nav-trigger-hover-background: #d6d9dd;
 $gcds-nav-group-top-nav-trigger-hover-text: #0535d2;
 $gcds-nav-group-top-nav-trigger-hover-decoration-thickness: 0.125rem;

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -104,12 +104,6 @@
         "type": "typography"
       },
       "trigger": {
-        "border": {
-          "width": {
-            "value": "{border.width.lg.value}",
-            "type": "borderWidth"
-          }
-        },
         "hover": {
           "background": {
             "value": "{color.grayscale.100.value}",


### PR DESCRIPTION
# Summary | Résumé

## Token being removed

The following nav-group token will be removed because it will no longer be used in the nav-group

- --gcds-nav-group-top-nav-trigger-border-width

## Bug fixes

Part of the fix for [this issue](https://github.com/cds-snc/gcds-components/issues/824).