### PR TITLE
chore:  switch to CDS Release Bot

### DIFF
--- a/.github/workflows/release_generator.yml
+++ b/.github/workflows/release_generator.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/create-github-app-token@136412a57a7081aa63c935a2cc2918f76c34f514 # v1.11.2
         id: sre_app_token
         with:
-          app_id: ${{ secrets.SRE_APP_ID }}
-          private_key: ${{ secrets.SRE_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
 
       - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
         with:


### PR DESCRIPTION
# Summary
Update the release please workflow to use a new, dedicated GitHub app for releases.  The reason for the change is so that we can scale back use of the SRE read/write app.

ℹ️  Note that this also updates the `actions/create-github-app-token` action's attributes as the underscore is being deprecated.

# Related
- https://github.com/cds-snc/platform-core-services/issues/707