### PR TITLE
feat: change nav-group bg to white within top-nav to match new design

### DIFF
--- a/build/figma/figma.tokens.json
+++ b/build/figma/figma.tokens.json
@@ -3802,7 +3802,7 @@
       "topNav": {
         "dropdown": {
           "background": {
-            "value": "#F1F2F3",
+            "value": "#FFF",
             "type": "color"
           },
           "box-shadow": {

--- a/build/tailwind/tailwind.tokens.json
+++ b/build/tailwind/tailwind.tokens.json
@@ -3802,7 +3802,7 @@
       "topNav": {
         "dropdown": {
           "background": {
-            "value": "#F1F2F3",
+            "value": "#FFF",
             "type": "color"
           },
           "box-shadow": {

--- a/build/web/css/components.css
+++ b/build/web/css/components.css
@@ -540,7 +540,7 @@
   --gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-  --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+  --gcds-nav-group-top-nav-dropdown-background: #ffffff;
   --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/build/web/css/components/nav-group.css
+++ b/build/web/css/components/nav-group.css
@@ -16,7 +16,7 @@
   --gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-  --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+  --gcds-nav-group-top-nav-dropdown-background: #ffffff;
   --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/build/web/css/tokens.css
+++ b/build/web/css/tokens.css
@@ -702,7 +702,7 @@
   --gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
   --gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
   --gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-  --gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+  --gcds-nav-group-top-nav-dropdown-background: #ffffff;
   --gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
   --gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
   --gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/build/web/scss/components.scss
+++ b/build/web/scss/components.scss
@@ -538,7 +538,7 @@ $gcds-nav-group-side-nav-trigger-font-weight: 600;
 $gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
 $gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
 $gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-$gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+$gcds-nav-group-top-nav-dropdown-background: #ffffff;
 $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/build/web/scss/components/nav-group.scss
+++ b/build/web/scss/components/nav-group.scss
@@ -14,7 +14,7 @@ $gcds-nav-group-side-nav-trigger-font-weight: 600;
 $gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
 $gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
 $gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-$gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+$gcds-nav-group-top-nav-dropdown-background: #ffffff;
 $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/build/web/scss/tokens.scss
+++ b/build/web/scss/tokens.scss
@@ -700,7 +700,7 @@ $gcds-nav-group-side-nav-trigger-font-weight: 600;
 $gcds-nav-group-side-nav-trigger-hover-background: #f1f2f3;
 $gcds-nav-group-side-nav-trigger-icon-margin: 1.125rem;
 $gcds-nav-group-side-nav-trigger-margin: 0.5rem;
-$gcds-nav-group-top-nav-dropdown-background: #f1f2f3;
+$gcds-nav-group-top-nav-dropdown-background: #ffffff;
 $gcds-nav-group-top-nav-dropdown-box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.25);
 $gcds-nav-group-top-nav-dropdown-padding: 0.75rem 0.75rem 0.125rem;
 $gcds-nav-group-top-nav-dropdown-width: 20rem;

--- a/tokens/components/nav-group/tokens.json
+++ b/tokens/components/nav-group/tokens.json
@@ -78,7 +78,7 @@
     "topNav": {
       "dropdown": {
         "background": {
-          "value": "{bg.light.value}",
+          "value": "{bg.white.value}",
           "type": "color"
         },
         "box-shadow": {


### PR DESCRIPTION
# Summary | Résumé

Update the background colour of the `nav-group` component to `white` if it is used within a `top-nav` to match the new design of the `top-nav` component.